### PR TITLE
Updated gem mining to have minimum amount of trips

### DIFF
--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -2265,13 +2265,14 @@ long check_out_imp_last_did(struct Thing *creatng)
       return false;
   case SDLstJob_DigOrMine:
       if (is_digging_indestructible_place(creatng)) {
-          // If we were digging gems, every tenth repeat of a gem-digging job, select another dungeon job.
-          // This allows to switch to other important tasks and not consuming all the diggers workforce forever
           dungeon = get_dungeon(creatng->owner);
+	  //don't reassign if it's the first gem dig since other tasks
 	  if (cctrl->digger.task_repeats != 0)
-	  {
-		if (((cctrl->digger.task_repeats % 10) == 0) && (dungeon->digger_stack_length > 1))
-		{  
+	  { 
+		// If we were digging gems, after 5 repeats of this job, a 1 in 20 chance to select another dungeon job.
+        // This allows to switch to other important tasks and not consuming all the diggers workforce forever
+		if ((( rand( ) % 20) == 1) && ((cctrl->digger.task_repeats % 5) == 0) && (dungeon->digger_stack_length > 1))
+		{
 		  // Set position in digger tasks list to a random place
 		  SYNCDBG(9,"Digger %s index %d reset due to neverending task",thing_model_name(creatng),(int)creatng->index);
 		  cctrl->digger.stack_update_turn = dungeon->digger_stack_update_turn;


### PR DESCRIPTION
Imps mining gems will now return at least 5 times to a gem patch, after
which there's a one in twenty chance to pick another job.