### PR TITLE
Simple reversion to former void parameter

### DIFF
--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -1616,7 +1616,7 @@ void process_computer_players2(void)
     }
 }
 
-void setup_computer_players2()
+void setup_computer_players2(void)
 {
   struct PlayerInfo *player;
   int i;


### PR DESCRIPTION
Reverted this one parameter change I accidentally left in the Skirmish commits (which does nothing either way but serves only as a protection), plus I was considering resolving a lot simple things that cause build warnings, but whatever, I'm going to work on something real now.

This wasn't even worth creating a branch over it's so insignificant.