### PR TITLE
Allowed easy laptop frameskip without numpad

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -211,20 +211,20 @@ void clip_frame_skip(void)
  */
 short get_speed_control_inputs(void)
 {
-  if (is_key_pressed(KC_ADD,KMod_CONTROL))
-  {
-      if (game.frame_skip < 2)
-        game.frame_skip ++;
-      else
-      if (game.frame_skip < 16)
-        game.frame_skip += 2;
-      else
-        game.frame_skip += (game.frame_skip/3);
-      clip_frame_skip();
-      show_onscreen_msg(game.num_fps+game.frame_skip, "Frame skip %d",game.frame_skip);
-      clear_key_pressed(KC_ADD);
-  }
-  if (is_key_pressed(KC_SUBTRACT,KMod_CONTROL))
+    if ((is_key_pressed(KC_ADD,KMod_CONTROL)) || (is_key_pressed(KC_EQUALS,KMod_CONTROL)))
+      {
+          if (game.frame_skip < 2)
+            game.frame_skip ++;
+          else
+          if (game.frame_skip < 16)
+            game.frame_skip += 2;
+          else
+            game.frame_skip += (game.frame_skip/3);
+          clip_frame_skip();
+          show_onscreen_msg(game.num_fps+game.frame_skip, "Frame skip %d",game.frame_skip);
+          clear_key_pressed(KC_ADD);
+      }
+      if ((is_key_pressed(KC_SUBTRACT,KMod_CONTROL)) || (is_key_pressed(KC_MINUS,KMod_CONTROL)))
   {
       if (game.frame_skip <= 2)
         game.frame_skip --;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -205,37 +205,67 @@ void clip_frame_skip(void)
     game.frame_skip = 0;
 }
 
+void increaseFrameskip(void)
+{
+    if (game.frame_skip < 2)
+    {
+        game.frame_skip ++;
+    }
+    else if (game.frame_skip < 16)
+    {
+        game.frame_skip += 2;
+    }
+    else
+    {
+        game.frame_skip += (game.frame_skip/3);
+    }
+    clip_frame_skip();
+    show_onscreen_msg(game.num_fps+game.frame_skip, "Frame skip %d",game.frame_skip);
+}
+
+void decreaseFrameskip(void)
+{
+    if (game.frame_skip <= 2)
+    {
+        game.frame_skip --;
+    }
+    else if (game.frame_skip <= 16)
+    {
+        game.frame_skip -= 2;
+    }
+    else
+    {
+        game.frame_skip -= (game.frame_skip/4);
+    }
+    clip_frame_skip();
+    show_onscreen_msg(game.num_fps+game.frame_skip, "Frame skip %d",game.frame_skip);
+}
+
 /**
  * Handles game speed control inputs.
  * @return Returns true if packet was created, false otherwise.
  */
 short get_speed_control_inputs(void)
 {
-    if ((is_key_pressed(KC_ADD,KMod_CONTROL)) || (is_key_pressed(KC_EQUALS,KMod_CONTROL)))
-      {
-          if (game.frame_skip < 2)
-            game.frame_skip ++;
-          else
-          if (game.frame_skip < 16)
-            game.frame_skip += 2;
-          else
-            game.frame_skip += (game.frame_skip/3);
-          clip_frame_skip();
-          show_onscreen_msg(game.num_fps+game.frame_skip, "Frame skip %d",game.frame_skip);
-          clear_key_pressed(KC_ADD);
-      }
-      if ((is_key_pressed(KC_SUBTRACT,KMod_CONTROL)) || (is_key_pressed(KC_MINUS,KMod_CONTROL)))
+  if (is_key_pressed(KC_ADD,KMod_CONTROL))
   {
-      if (game.frame_skip <= 2)
-        game.frame_skip --;
-      else
-      if (game.frame_skip <= 16)
-        game.frame_skip -= 2;
-      else
-        game.frame_skip -= (game.frame_skip/4);
-      clip_frame_skip();
-      show_onscreen_msg(game.num_fps+game.frame_skip, "Frame skip %d",game.frame_skip);
+      increaseFrameskip();
+      clear_key_pressed(KC_ADD);
+  }
+  if (is_key_pressed(KC_EQUALS,KMod_CONTROL))
+  {
+      increaseFrameskip();
+      clear_key_pressed(KC_EQUALS);
+  }
+  if (is_key_pressed(KC_SUBTRACT,KMod_CONTROL))
+  {
+      decreaseFrameskip();
       clear_key_pressed(KC_SUBTRACT);
+  }
+  if (is_key_pressed(KC_MINUS,KMod_CONTROL))
+  {
+      decreaseFrameskip();
+      clear_key_pressed(KC_MINUS);
   }
   return false;
 }


### PR DESCRIPTION
In addition to using the ctrl+ or ctrl- with the numpad keys, it works on the main area of the keyboard as well with the plus and minus keys. For increasing frameskip, it's actually listening for ctrl and the equals key at the same time (since otherwise you would have to push the shift key to change the equals key to plus).

If you like this and merge, maybe don't delete this particular branch, for adding or tweaking hotkeys in the future if anyone has any other suggestions.