### PR TITLE
PushOnHit + Firebomb explosion

### DIFF
--- a/config_magic.c
+++ b/config_magic.c
@@ -1,0 +1,1710 @@
+/******************************************************************************/
+// Free implementation of Bullfrog's Dungeon Keeper strategy game.
+/******************************************************************************/
+/** @file config_magic.c
+ *     Keeper and creature spells configuration loading functions.
+ * @par Purpose:
+ *     Support of configuration files for magic spells.
+ * @par Comment:
+ *     None.
+ * @author   Tomasz Lis
+ * @date     25 May 2009 - 26 Jul 2009
+ * @par  Copying and copyrights:
+ *     This program is free software; you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation; either version 2 of the License, or
+ *     (at your option) any later version.
+ */
+/******************************************************************************/
+#include "config_magic.h"
+#include "globals.h"
+
+#include "bflib_basics.h"
+#include "bflib_memory.h"
+#include "bflib_fileio.h"
+#include "bflib_dernc.h"
+
+#include "config.h"
+#include "config_effects.h"
+#include "config_objects.h"
+#include "config_players.h"
+#include "thing_doors.h"
+#include "thing_physics.h"
+#include "thing_effects.h"
+#include "power_process.h"
+#include "game_legacy.h"
+
+#include "keeperfx.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/******************************************************************************/
+const char keeper_magic_file[]="magic.cfg";
+
+const struct NamedCommand magic_common_commands[] = {
+  {"SPELLSCOUNT",     1},
+  {"SHOTSCOUNT",      2},
+  {"POWERCOUNT",      3},
+  {"SPECIALSCOUNT",   4},
+  {NULL,              0},
+  };
+
+const struct NamedCommand magic_spell_commands[] = {
+  {"NAME",            1},
+  {"DURATION",        2},
+  {"SELFCASTED",      3},
+  {"CASTATTHING",     4},
+  {"SHOTMODEL",       5},
+  {"EFFECTMODEL",     6},
+  {"SYMBOLSPRITES",   7},
+  {NULL,              0},
+  };
+
+const struct NamedCommand magic_shot_commands[] = {
+  {"NAME",            1},
+  {"HEALTH",          2},
+  {"DAMAGE",          3},
+  {"DAMAGETYPE",      4},
+  {"HITTYPE",         5},
+  {"AREADAMAGE",      6},
+  {"SPEED",           7},
+  {"PROPERTIES",      8},
+  {NULL,              0},
+  };
+
+const struct NamedCommand magic_power_commands[] = {
+  {"NAME",            1},
+  {"POWER",           2},
+  {"COST",            3},
+  {"TIME",            4},
+  {"CASTABILITY",     5},
+  {"ARTIFACT",        6},
+  {"NAMETEXTID",      7},
+  {"TOOLTIPTEXTID",   8},
+  {"SYMBOLSPRITES",  10},
+  {"POINTERSPRITES", 11},
+  {"PANELTABINDEX",  12},
+  {"SOUNDSAMPLES",   13},
+  {"PROPERTIES",     14},
+  {"FUNCTIONS",      15},
+  {"PLAYERSTATE",    16},
+  {"PARENTPOWER",    17},
+  {NULL,              0},
+  };
+
+const struct NamedCommand magic_special_commands[] = {
+  {"NAME",            1},
+  {"ARTIFACT",        2},
+  {"TOOLTIPTEXTID",   3},
+  {NULL,              0},
+  };
+
+const struct NamedCommand shotmodel_properties_commands[] = {
+  {"SLAPPABLE",         1},
+  {"NAVIGABLE",         2},
+  {"BOULDER",           3},
+  {NULL,                0},
+  };
+
+const struct NamedCommand powermodel_castability_commands[] = {
+  {"CUSTODY_CRTRS",    PwCast_CustodyCrtrs},
+  {"OWNED_CRTRS",      PwCast_OwnedCrtrs},
+  {"ALLIED_CRTRS",     PwCast_AlliedCrtrs},
+  {"ENEMY_CRTRS",      PwCast_EnemyCrtrs},
+  {"UNCONSC_CRTRS",    PwCast_NConscCrtrs},
+  {"BOUND_CRTRS",      PwCast_BoundCrtrs},
+  {"UNCLMD_GROUND",    PwCast_UnclmdGround},
+  {"NEUTRL_GROUND",    PwCast_NeutrlGround},
+  {"OWNED_GROUND",     PwCast_OwnedGround},
+  {"ALLIED_GROUND",    PwCast_AlliedGround},
+  {"ENEMY_GROUND",     PwCast_EnemyGround},
+  {"NEUTRL_TALL",      PwCast_NeutrlTall},
+  {"OWNED_TALL",       PwCast_OwnedTall},
+  {"ALLIED_TALL",      PwCast_AlliedTall},
+  {"ENEMY_TALL",       PwCast_EnemyTall},
+  {"OWNED_FOOD",       PwCast_OwnedFood},
+  {"NEUTRL_FOOD",      PwCast_NeutrlFood},
+  {"ENEMY_FOOD",       PwCast_EnemyFood},
+  {"OWNED_GOLD",       PwCast_OwnedGold},
+  {"NEUTRL_GOLD",      PwCast_NeutrlGold},
+  {"ENEMY_GOLD",       PwCast_EnemyGold},
+  {"OWNED_SPELL",      PwCast_OwnedSpell},
+  {"OWNED_BOULDERS",   PwCast_OwnedBoulders},
+  {"NEEDS_DELAY",      PwCast_NeedsDelay},
+  {"CLAIMABLE",        PwCast_Claimable},
+  {"UNREVEALED",       PwCast_Unrevealed},
+  {"REVEALED_TEMP",    PwCast_RevealedTemp},
+  {"THING_OR_MAP",     PwCast_ThingOrMap},
+  {"ANYWHERE",         PwCast_Anywhere},
+  {"ALL_CRTRS",        PwCast_AllCrtrs},
+  {"ALL_FOOD",         PwCast_AllFood},
+  {"ALL_GOLD",         PwCast_AllGold},
+  {"ALL_THINGS",       PwCast_AllThings},
+  {"ALL_GROUND",       PwCast_AllGround},
+  {"NOT_ENEMY_GROUND", PwCast_NotEnemyGround},
+  {"ALL_TALL",         PwCast_AllTall},
+  {NULL,                0},
+  };
+
+const struct NamedCommand powermodel_properties_commands[] = {
+    {"INSTINCTIVE",       PwCF_Instinctive},
+    {"HAS_PROGRESS",      PwCF_HasProgress},
+    {NULL,                0},
+};
+
+const struct NamedCommand shotmodel_damagetype_commands[] = {
+  {"NONE",        DmgT_None},
+  {"PHYSICAL",    DmgT_Physical},
+  {"ELECTRIC",    DmgT_Electric},
+  {"COMBUSTION",  DmgT_Combustion},
+  {"FROSTBITE",   DmgT_Frostbite},
+  {"HEATBURN",    DmgT_Heatburn},
+  {"BIOLOGICAL",  DmgT_Biological},
+  {"MAGICAL",     DmgT_Magical},
+  {"RESPIRATORY", DmgT_Respiratory},
+  {"RESTORATION", DmgT_Restoration},
+  {NULL,          DmgT_None},
+  };
+
+const struct NamedCommand powermodel_expand_check_func_type[] = {
+  {"general_expand",           1},
+  {"sight_of_evil_expand",     2},
+  {"call_to_arms_expand",      3},
+  {"do_not_expand",            4},
+  {NULL,                       0},
+};
+
+const Expand_Check_Func powermodel_expand_check_func_list[] = {
+  NULL,
+  general_expand_check,
+  sight_of_evil_expand_check,
+  call_to_arms_expand_check,
+  NULL,
+  NULL,
+};
+
+/******************************************************************************/
+struct MagicConfig magic_conf;
+struct NamedCommand spell_desc[MAGIC_ITEMS_MAX];
+struct NamedCommand shot_desc[MAGIC_ITEMS_MAX];
+struct NamedCommand power_desc[MAGIC_ITEMS_MAX];
+struct NamedCommand special_desc[MAGIC_ITEMS_MAX];
+/******************************************************************************/
+#ifdef __cplusplus
+}
+#endif
+/******************************************************************************/
+struct SpellInfo *get_magic_info(int mgc_idx)
+{
+  if ((mgc_idx < 0) || (mgc_idx >= MAGIC_TYPES_COUNT))
+    return &spell_info[0];
+  return &spell_info[mgc_idx];
+}
+
+TbBool magic_info_is_invalid(const struct SpellInfo *mgcinfo)
+{
+  if (mgcinfo <= &spell_info[0])
+    return true;
+  return false;
+}
+
+struct SpellData *get_power_data(int pwkind)
+{
+  if ((pwkind > 0) && (pwkind < POWER_TYPES_COUNT))
+    return &spell_data[pwkind];
+  if ((pwkind < -1) || (pwkind >= POWER_TYPES_COUNT))
+    ERRORLOG("Request of invalid power (no %d) intercepted",pwkind);
+  return &spell_data[0];
+}
+
+TextStringId get_power_name_strindex(int pwkind)
+{
+  if ((pwkind < 0) || (pwkind >= magic_conf.power_types_count))
+    return magic_conf.power_cfgstats[0].name_stridx;
+  return magic_conf.power_cfgstats[pwkind].name_stridx;
+}
+
+TextStringId get_power_description_strindex(int pwkind)
+{
+  if ((pwkind < 0) || (pwkind >= magic_conf.power_types_count))
+    return magic_conf.power_cfgstats[0].tooltip_stridx;
+  return magic_conf.power_cfgstats[pwkind].tooltip_stridx;
+}
+
+long get_special_description_strindex(int spckind)
+{
+  if ((spckind < 0) || (spckind >= magic_conf.power_types_count))
+    return magic_conf.special_cfgstats[0].tooltip_stridx;
+  return magic_conf.special_cfgstats[spckind].tooltip_stridx;
+}
+
+long get_power_index_for_work_state(long work_state)
+{
+    long i;
+    for (i=0; i < magic_conf.power_types_count; i++)
+    {
+        if (magic_conf.power_cfgstats[i].work_state == work_state) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+struct SpellConfigStats *get_spell_model_stats(SpellKind spmodel)
+{
+    if ((spmodel < 0) || (spmodel >= magic_conf.spell_types_count))
+        return &magic_conf.spell_cfgstats[0];
+    return &magic_conf.spell_cfgstats[spmodel];
+}
+
+struct ShotConfigStats *get_shot_model_stats(ThingModel tngmodel)
+{
+    if ((tngmodel < 0) || (tngmodel >= magic_conf.shot_types_count))
+        return &magic_conf.shot_cfgstats[0];
+    return &magic_conf.shot_cfgstats[tngmodel];
+}
+
+struct PowerConfigStats *get_power_model_stats(PowerKind pwkind)
+{
+    if ((pwkind < 0) || (pwkind >= magic_conf.power_types_count))
+        return &magic_conf.power_cfgstats[0];
+    return &magic_conf.power_cfgstats[pwkind];
+}
+
+TbBool power_model_stats_invalid(const struct PowerConfigStats *powerst)
+{
+  if (powerst <= &magic_conf.power_cfgstats[0])
+    return true;
+  return false;
+}
+
+struct MagicStats *get_power_dynamic_stats(PowerKind pwkind)
+{
+    if ((pwkind < 0) || (pwkind >= POWER_TYPES_COUNT))
+        return &game.keeper_power_stats[0];
+    return &game.keeper_power_stats[pwkind];
+}
+
+TbBool power_is_instinctive(int pwkind)
+{
+    const struct PowerConfigStats *powerst;
+    powerst = get_power_model_stats(pwkind);
+    // Invalid powers are instinctive (as this usually means skipping an action)
+    if (power_model_stats_invalid(powerst))
+        return true;
+    return ((powerst->config_flags & PwCF_Instinctive) != 0);
+}
+
+struct SpecialConfigStats *get_special_model_stats(SpecialKind spckind)
+{
+    if ((spckind < 0) || (spckind >= magic_conf.special_types_count))
+        return &magic_conf.special_cfgstats[0];
+    return &magic_conf.special_cfgstats[spckind];
+}
+
+short write_magic_shot_to_log(const struct ShotConfigStats *shotst, int num)
+{
+  JUSTMSG("[shot%d]",(int)num);
+  JUSTMSG("Name = %s",shotst->code_name);
+  JUSTMSG("Values = %d %d",(int)shotst->old->deals_magic_damage,(int)shotst->old->experience_given_to_shooter);
+  return true;
+}
+
+TbBool parse_magic_common_blocks(char *buf, long len, const char *config_textname, unsigned short flags)
+{
+    long pos;
+    int k,n;
+    int cmd_num;
+    // Block name and parameter word store variables
+    char block_buf[COMMAND_WORD_LEN];
+    char word_buf[COMMAND_WORD_LEN];
+    // Initialize block data
+    if ((flags & CnfLd_AcceptPartial) == 0)
+    {
+        magic_conf.spell_types_count = 1;
+        magic_conf.shot_types_count = 1;
+        magic_conf.power_types_count = 1;
+        magic_conf.special_types_count = 1;
+    }
+    // Find the block
+    sprintf(block_buf,"common");
+    pos = 0;
+    k = find_conf_block(buf,&pos,len,block_buf);
+    if (k < 0)
+    {
+        if ((flags & CnfLd_AcceptPartial) == 0)
+            WARNMSG("Block [%s] not found in %s file.",block_buf,config_textname);
+        return false;
+    }
+#define COMMAND_TEXT(cmd_num) get_conf_parameter_text(magic_common_commands,cmd_num)
+    while (pos<len)
+    {
+        // Finding command number in this line
+        cmd_num = recognize_conf_command(buf,&pos,len,magic_common_commands);
+        // Now store the config item in correct place
+        if (cmd_num == -3) break; // if next block starts
+        n = 0;
+        switch (cmd_num)
+        {
+        case 1: // SPELLSCOUNT
+            if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+            {
+              k = atoi(word_buf);
+              if ((k > 0) && (k <= MAGIC_ITEMS_MAX))
+              {
+                magic_conf.spell_types_count = k;
+                n++;
+              }
+            }
+            if (n < 1)
+            {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+            }
+            break;
+        case 2: // SHOTSCOUNT
+            if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+            {
+              k = atoi(word_buf);
+              if ((k > 0) && (k <= MAGIC_ITEMS_MAX))
+              {
+                magic_conf.shot_types_count = k;
+                n++;
+              }
+            }
+            if (n < 1)
+            {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+            }
+            break;
+        case 3: // POWERCOUNT
+            if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+            {
+              k = atoi(word_buf);
+              if ((k > 0) && (k <= MAGIC_ITEMS_MAX))
+              {
+                magic_conf.power_types_count = k;
+                n++;
+              }
+            }
+            if (n < 1)
+            {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+            }
+            break;
+        case 4: // SPECIALSCOUNT
+            if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+            {
+              k = atoi(word_buf);
+              if ((k > 0) && (k <= MAGIC_ITEMS_MAX))
+              {
+                magic_conf.special_types_count = k;
+                n++;
+              }
+            }
+            if (n < 1)
+            {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+            }
+            break;
+        case 0: // comment
+            break;
+        case -1: // end of buffer
+            break;
+        default:
+            CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s file.",
+                cmd_num,block_buf,config_textname);
+            break;
+        }
+        skip_conf_to_next_line(buf,&pos,len);
+    }
+#undef COMMAND_TEXT
+    return true;
+}
+
+TbBool parse_magic_spell_blocks(char *buf, long len, const char *config_textname, unsigned short flags)
+{
+  struct SpellConfigStats *spellst;
+  struct SpellConfig *splconf;
+  struct SpellInfo *spinfo;
+  long pos;
+  int i,k,n;
+  int cmd_num;
+  // Block name and parameter word store variables
+  char block_buf[COMMAND_WORD_LEN];
+  char word_buf[COMMAND_WORD_LEN];
+  // Initialize the array
+  int arr_size;
+  if ((flags & CnfLd_AcceptPartial) == 0)
+  {
+      arr_size = sizeof(magic_conf.spell_cfgstats)/sizeof(magic_conf.spell_cfgstats[0]);
+      for (i=0; i < arr_size; i++)
+      {
+          spellst = get_spell_model_stats(i);
+          LbMemorySet(spellst->code_name, 0, COMMAND_WORD_LEN);
+          if (i < magic_conf.spell_types_count)
+          {
+            spell_desc[i].name = spellst->code_name;
+            spell_desc[i].num = i;
+          } else
+          {
+            spell_desc[i].name = NULL;
+            spell_desc[i].num = 0;
+          }
+      }
+      arr_size = magic_conf.spell_types_count;
+      for (i=0; i < arr_size; i++)
+      {
+          splconf = &game.spells_config[i];
+          splconf->duration = 0;
+          spinfo = get_magic_info(i);
+          spinfo->caster_affected = 0;
+          spinfo->caster_affect_sound = 0;
+          spinfo->cast_at_thing = 0;
+          spinfo->shot_model = 0;
+          spinfo->cast_effect_model = 0;
+          spinfo->bigsym_sprite_idx = 0;
+          spinfo->medsym_sprite_idx = 0;
+      }
+  }
+  // Load the file
+  arr_size = magic_conf.spell_types_count;
+  for (i=0; i < arr_size; i++)
+  {
+    sprintf(block_buf,"spell%d",i);
+    pos = 0;
+    k = find_conf_block(buf,&pos,len,block_buf);
+    if (k < 0)
+    {
+        if ((flags & CnfLd_AcceptPartial) == 0) {
+            WARNMSG("Block [%s] not found in %s file.",block_buf,config_textname);
+            return false;
+        }
+        continue;
+    }
+    splconf = &game.spells_config[i];
+    spinfo = get_magic_info(i);
+    spellst = get_spell_model_stats(i);
+#define COMMAND_TEXT(cmd_num) get_conf_parameter_text(magic_spell_commands,cmd_num)
+    while (pos<len)
+    {
+      // Finding command number in this line
+      cmd_num = recognize_conf_command(buf,&pos,len,magic_spell_commands);
+      // Now store the config item in correct place
+      if (cmd_num == -3) break; // if next block starts
+      if ((flags & CnfLd_ListOnly) != 0) {
+          // In "List only" mode, accept only name command
+          if (cmd_num > 1) {
+              cmd_num = 0;
+          }
+      }
+      n = 0;
+      switch (cmd_num)
+      {
+      case 1: // NAME
+          if (get_conf_parameter_single(buf,&pos,len,spellst->code_name,COMMAND_WORD_LEN) <= 0)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+              break;
+          }
+          n++;
+          break;
+      case 2: // DURATION
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              splconf->duration = k;
+              n++;
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 3: // SELFCASTED
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              spinfo->caster_affected = k;
+              n++;
+          }
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              spinfo->caster_affect_sound = k;
+              n++;
+          }
+          if (n < 2)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 4: // CASTATTHING
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              spinfo->cast_at_thing = k;
+              n++;
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 5: // SHOTMODEL
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(shot_desc, word_buf);
+              if (k >= 0) {
+                  spinfo->shot_model = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect shot model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 6: // EFFECTMODEL
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(effect_desc, word_buf);
+              if (k >= 0) {
+                  spinfo->cast_effect_model = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect effect model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 7: // SYMBOLSPRITES
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  spinfo->bigsym_sprite_idx = k;
+                  n++;
+              }
+          }
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  spinfo->medsym_sprite_idx = k;
+                  n++;
+              }
+          }
+          if (n < 2)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 0: // comment
+          break;
+      case -1: // end of buffer
+          break;
+      default:
+          CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s file.",
+              cmd_num,block_buf,config_textname);
+          break;
+      }
+      skip_conf_to_next_line(buf,&pos,len);
+    }
+#undef COMMAND_TEXT
+  }
+  return true;
+}
+
+TbBool parse_magic_shot_blocks(char *buf, long len, const char *config_textname, unsigned short flags)
+{
+  struct ShotConfigStats *shotst;
+  long pos;
+  int i,k,n;
+  int cmd_num;
+  // Block name and parameter word store variables
+  char block_buf[COMMAND_WORD_LEN];
+  char word_buf[COMMAND_WORD_LEN];
+  // Initialize the array
+  int arr_size;
+  if ((flags & CnfLd_AcceptPartial) == 0)
+  {
+      arr_size = sizeof(magic_conf.shot_cfgstats)/sizeof(magic_conf.shot_cfgstats[0]);
+      for (i=0; i < arr_size; i++)
+      {
+          shotst = get_shot_model_stats(i);
+          LbMemorySet(shotst->code_name, 0, COMMAND_WORD_LEN);
+          shotst->model_flags = 0;
+          if (i < 30)
+              shotst->old = &shot_stats[i];
+          else
+              shotst->old = &shot_stats[0];
+          if (i < magic_conf.shot_types_count)
+          {
+            shot_desc[i].name = shotst->code_name;
+            shot_desc[i].num = i;
+          } else
+          {
+            shot_desc[i].name = NULL;
+            shot_desc[i].num = 0;
+          }
+          shotst->area_hit_type = THit_CrtrsOnly;
+          shotst->area_range = 0;
+          shotst->area_damage = 0;
+          shotst->area_blow = 0;
+      }
+  }
+  // Load the file
+  arr_size = magic_conf.shot_types_count;
+  for (i=0; i < arr_size; i++)
+  {
+    sprintf(block_buf,"shot%d",i);
+    pos = 0;
+    k = find_conf_block(buf,&pos,len,block_buf);
+    if (k < 0)
+    {
+        if ((flags & CnfLd_AcceptPartial) == 0) {
+            WARNMSG("Block [%s] not found in %s file.",block_buf,config_textname);
+            return false;
+        }
+        continue;
+    }
+    shotst = get_shot_model_stats(i);
+#define COMMAND_TEXT(cmd_num) get_conf_parameter_text(magic_shot_commands,cmd_num)
+    while (pos<len)
+    {
+      // Finding command number in this line
+      cmd_num = recognize_conf_command(buf,&pos,len,magic_shot_commands);
+      // Now store the config item in correct place
+      if (cmd_num == -3) break; // if next block starts
+      if ((flags & CnfLd_ListOnly) != 0) {
+          // In "List only" mode, accept only name command
+          if (cmd_num > 1) {
+              cmd_num = 0;
+          }
+      }
+      n = 0;
+      switch (cmd_num)
+      {
+      case 1: // NAME
+          if (get_conf_parameter_single(buf,&pos,len,shotst->code_name,COMMAND_WORD_LEN) <= 0)
+          {
+            CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+            break;
+          }
+          n++;
+          break;
+      case 2: // HEALTH
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = atoi(word_buf);
+            shotst->health = k;
+            n++;
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 3: // DAMAGE
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = atoi(word_buf);
+            shotst->old->damage = k;
+            n++;
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 4: // DAMAGETYPE
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(shotmodel_damagetype_commands, word_buf);
+              if (k >= 0) {
+                  shotst->damage_type = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect shot model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 5: // HITTYPE
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              shotst->area_hit_type = k;
+              n++;
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 6: // AREADAMAGE
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              shotst->area_range = k;
+              n++;
+          }
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              shotst->area_damage = k;
+              n++;
+          }
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              shotst->area_blow = k;
+              n++;
+          }
+          if (n < 3)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 7: // SPEED
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = atoi(word_buf);
+            shotst->old->speed = k;
+            n++;
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 8: // PROPERTIES
+          shotst->model_flags = 0;
+          while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = get_id(shotmodel_properties_commands, word_buf);
+            switch (k)
+            {
+            case 1: // SLAPPABLE
+                shotst->model_flags |= ShMF_Slappable;
+                n++;
+                break;
+            case 2: // NAVIGABLE
+                shotst->model_flags |= ShMF_Navigable;
+                n++;
+                break;
+            case 3: // BOULDER
+                shotst->model_flags |= ShMF_Boulder;
+                n++;
+                break;
+            default:
+                CONFWRNLOG("Incorrect value of \"%s\" parameter \"%s\" in [%s] block of %s file.",
+                    COMMAND_TEXT(cmd_num),word_buf,block_buf,config_textname);
+                break;
+            }
+          }
+	  case 9: // PUSHONHIT
+		  if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+		  {
+			  k = atoi(word_buf);
+			  shotst->old->push_on_hit = k;
+			  n++;
+		  }
+		  if (n < 1)
+		  {
+			  CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+				  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+		  }
+		  break;
+          break;
+      case 0: // comment
+          break;
+      case -1: // end of buffer
+          break;
+      default:
+          CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s file.",
+              cmd_num,block_buf,config_textname);
+          break;
+      }
+      skip_conf_to_next_line(buf,&pos,len);
+    }
+    //write_magic_shot_to_log(shotst, i);
+#undef COMMAND_TEXT
+  }
+  return true;
+}
+
+TbBool parse_magic_power_blocks(char *buf, long len, const char *config_textname, unsigned short flags)
+{
+  struct PowerConfigStats *powerst;
+  struct MagicStats *pwrdynst;
+  long pos;
+  int i,k,n;
+  int cmd_num;
+  // Block name and parameter word store variables
+  char block_buf[COMMAND_WORD_LEN];
+  char word_buf[COMMAND_WORD_LEN];
+  // Initialize the array
+  int arr_size;
+  if ((flags & CnfLd_AcceptPartial) == 0)
+  {
+      arr_size = sizeof(magic_conf.power_cfgstats)/sizeof(magic_conf.power_cfgstats[0]);
+      for (i=0; i < arr_size; i++)
+      {
+          powerst = get_power_model_stats(i);
+          LbMemorySet(powerst->code_name, 0, COMMAND_WORD_LEN);
+          powerst->artifact_model = 0;
+          powerst->can_cast_flags = 0;
+          powerst->config_flags = 0;
+          powerst->overcharge_check = NULL;
+          powerst->work_state = 0;
+          powerst->bigsym_sprite_idx = 0;
+          powerst->medsym_sprite_idx = 0;
+          powerst->name_stridx = 0;
+          powerst->tooltip_stridx = 0;
+          powerst->select_sample_idx = 0;
+          powerst->pointer_sprite_idx = 0;
+          powerst->panel_tab_idx = 0;
+          if (i < magic_conf.power_types_count)
+          {
+              power_desc[i].name = powerst->code_name;
+              power_desc[i].num = i;
+          } else
+          {
+              power_desc[i].name = NULL;
+              power_desc[i].num = 0;
+          }
+      }
+      arr_size = sizeof(object_conf.object_to_power_artifact)/sizeof(object_conf.object_to_power_artifact[0]);
+      for (i=0; i < arr_size; i++) {
+          object_conf.object_to_power_artifact[i] = 0;
+      }
+  }
+  arr_size = magic_conf.power_types_count;
+  // Load the file
+  for (i=0; i < arr_size; i++)
+  {
+    sprintf(block_buf,"power%d",i);
+    pos = 0;
+    k = find_conf_block(buf,&pos,len,block_buf);
+    if (k < 0)
+    {
+        if ((flags & CnfLd_AcceptPartial) == 0) {
+            WARNMSG("Block [%s] not found in %s file.",block_buf,config_textname);
+            return false;
+        }
+        continue;
+    }
+    pwrdynst = get_power_dynamic_stats(i);
+    powerst = get_power_model_stats(i);
+#define COMMAND_TEXT(cmd_num) get_conf_parameter_text(magic_power_commands,cmd_num)
+    while (pos<len)
+    {
+      // Finding command number in this line
+      cmd_num = recognize_conf_command(buf,&pos,len,magic_power_commands);
+      // Now store the config item in correct place
+      if (cmd_num == -3) break; // if next block starts
+      if ((flags & CnfLd_ListOnly) != 0) {
+          // In "List only" mode, accept only name command
+          if (cmd_num > 1) {
+              cmd_num = 0;
+          }
+      }
+      n = 0;
+      switch (cmd_num)
+      {
+      case 1: // NAME
+          if (get_conf_parameter_single(buf,&pos,len,powerst->code_name,COMMAND_WORD_LEN) <= 0)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+              break;
+          }
+          break;
+      case 2: // POWER
+          while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (n > SPELL_MAX_LEVEL)
+              {
+                CONFWRNLOG("Too many \"%s\" parameters in [%s] block of %s file.",
+                    COMMAND_TEXT(cmd_num),block_buf,config_textname);
+                break;
+              }
+              pwrdynst->strength[n] = k;
+              n++;
+          }
+          if (n <= SPELL_MAX_LEVEL)
+          {
+              CONFWRNLOG("Couldn't read all \"%s\" parameters in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 3: // COST
+          while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (n > SPELL_MAX_LEVEL)
+              {
+                CONFWRNLOG("Too many \"%s\" parameters in [%s] block of %s file.",
+                    COMMAND_TEXT(cmd_num),block_buf,config_textname);
+                break;
+              }
+              pwrdynst->cost[n] = k;
+              n++;
+          }
+          if (n <= SPELL_MAX_LEVEL)
+          {
+              CONFWRNLOG("Couldn't read all \"%s\" parameters in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 4: // TIME
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              pwrdynst->time = k;
+              n++;
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 5: // CASTABILITY
+          powerst->can_cast_flags = 0;
+          while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(powermodel_castability_commands, word_buf);
+              if ((k != 0) && (k != -1))
+              {
+                  powerst->can_cast_flags |= k;
+                  n++;
+              } else
+              {
+                  CONFWRNLOG("Incorrect value of \"%s\" parameter \"%s\" in [%s] block of %s file.",
+                      COMMAND_TEXT(cmd_num),word_buf,block_buf,config_textname);
+              }
+          }
+          break;
+      case 6: // ARTIFACT
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(object_desc, word_buf);
+              if (k >= 0) {
+                  powerst->artifact_model = k;
+                  object_conf.object_to_power_artifact[k] = i;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect object model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 7: // NAMETEXTID
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              powerst->name_stridx = k;
+              n++;
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 8: // TOOLTIPTEXTID
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              powerst->tooltip_stridx = k;
+              n++;
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 10: // SYMBOLSPRITES
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  powerst->bigsym_sprite_idx = k;
+                  n++;
+              }
+          }
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  powerst->medsym_sprite_idx = k;
+                  n++;
+              }
+          }
+          if (n < 2)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 11: // POINTERSPRITES
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  powerst->pointer_sprite_idx = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 12: // PANELTABINDEX
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = atoi(word_buf);
+            if (k >= 0)
+            {
+                powerst->panel_tab_idx = k;
+                n++;
+            }
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 13: // SOUNDSAMPLES
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = atoi(word_buf);
+            if (k >= 0)
+            {
+                powerst->select_sample_idx = k;
+                n++;
+            }
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 14: // PROPERTIES
+          powerst->config_flags = 0;
+          while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(powermodel_properties_commands, word_buf);
+              if (k > 0) {
+                  powerst->config_flags |= k;
+                  n++;
+              } else {
+                  CONFWRNLOG("Incorrect value of \"%s\" parameter \"%s\" in [%s] block of %s file.",
+                      COMMAND_TEXT(cmd_num),word_buf,block_buf,config_textname);
+              }
+          }
+          break;
+      case 15: // FUNCTIONS
+          powerst->overcharge_check = NULL;
+          k = recognize_conf_parameter(buf,&pos,len,powermodel_expand_check_func_type);
+          if (k > 0)
+          {
+              powerst->overcharge_check = powermodel_expand_check_func_list[k];
+              n++;
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 16: // PLAYERSTATE
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(player_state_commands, word_buf);
+              if (k >= 0) {
+                  powerst->work_state = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect object model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 17: // PARENTPOWER
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(power_desc, word_buf);
+              if (k >= 0) {
+                  powerst->parent_power = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect object model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 0: // comment
+          break;
+      case -1: // end of buffer
+          break;
+      default:
+          CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s file.",
+              cmd_num,block_buf,config_textname);
+          break;
+      }
+      skip_conf_to_next_line(buf,&pos,len);
+    }
+#undef COMMAND_TEXT
+  }
+  if ((flags & CnfLd_ListOnly) == 0)
+  {
+    // Mark powers which have children
+    for (i = 0; i < magic_conf.power_types_count; i++)
+    {
+        powerst = get_power_model_stats(i);
+        struct PowerConfigStats *parent_powerst;
+        parent_powerst = get_power_model_stats(powerst->parent_power);
+        if (!power_model_stats_invalid(parent_powerst)) {
+            parent_powerst->config_flags |= PwCF_IsParent;
+        }
+    }
+  }
+  return true;
+}
+
+TbBool parse_magic_special_blocks(char *buf, long len, const char *config_textname, unsigned short flags)
+{
+  struct SpecialConfigStats *specst;
+  long pos;
+  int i,k,n;
+  int cmd_num;
+  // Block name and parameter word store variables
+  char block_buf[COMMAND_WORD_LEN];
+  char word_buf[COMMAND_WORD_LEN];
+  // Initialize the array
+  int arr_size;
+  if ((flags & CnfLd_AcceptPartial) == 0)
+  {
+      arr_size = sizeof(magic_conf.special_cfgstats)/sizeof(magic_conf.special_cfgstats[0]);
+      for (i=0; i < arr_size; i++)
+      {
+          specst = get_special_model_stats(i);
+          LbMemorySet(specst->code_name, 0, COMMAND_WORD_LEN);
+          specst->artifact_model = 0;
+          specst->tooltip_stridx = 0;
+          if (i < magic_conf.special_types_count)
+          {
+              special_desc[i].name = specst->code_name;
+              special_desc[i].num = i;
+          } else
+          {
+              special_desc[i].name = NULL;
+              special_desc[i].num = 0;
+          }
+      }
+      arr_size = sizeof(object_conf.object_to_special_artifact)/sizeof(object_conf.object_to_special_artifact[0]);
+      for (i=0; i < arr_size; i++) {
+          object_conf.object_to_special_artifact[i] = 0;
+      }
+  }
+  arr_size = magic_conf.special_types_count;
+  // Load the file
+  for (i=0; i < arr_size; i++)
+  {
+    sprintf(block_buf,"special%d",i);
+    pos = 0;
+    k = find_conf_block(buf,&pos,len,block_buf);
+    if (k < 0)
+    {
+        if ((flags & CnfLd_AcceptPartial) == 0) {
+            WARNMSG("Block [%s] not found in %s file.",block_buf,config_textname);
+            return false;
+        }
+        continue;
+    }
+    specst = get_special_model_stats(i);
+#define COMMAND_TEXT(cmd_num) get_conf_parameter_text(magic_special_commands,cmd_num)
+    while (pos<len)
+    {
+      // Finding command number in this line
+      cmd_num = recognize_conf_command(buf,&pos,len,magic_special_commands);
+      // Now store the config item in correct place
+      if (cmd_num == -3) break; // if next block starts
+      if ((flags & CnfLd_ListOnly) != 0) {
+          // In "List only" mode, accept only name command
+          if (cmd_num > 1) {
+              cmd_num = 0;
+          }
+      }
+      n = 0;
+      switch (cmd_num)
+      {
+      case 1: // NAME
+          if (get_conf_parameter_single(buf,&pos,len,specst->code_name,COMMAND_WORD_LEN) <= 0)
+          {
+              CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num),block_buf,config_textname);
+              break;
+          }
+          break;
+      case 2: // ARTIFACT
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+              k = get_id(object_desc, word_buf);
+              if (k >= 0) {
+                  specst->artifact_model = k;
+                  object_conf.object_to_special_artifact[k] = i;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect object model \"%s\" in [%s] block of %s file.",
+                  word_buf,block_buf,config_textname);
+              break;
+          }
+          break;
+      case 3: // TOOLTIPTEXTID
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            k = atoi(word_buf);
+            if (k > 0)
+            {
+                specst->tooltip_stridx = k;
+                n++;
+            }
+          }
+          if (n < 1)
+          {
+            CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                COMMAND_TEXT(cmd_num),block_buf,config_textname);
+          }
+          break;
+      case 0: // comment
+          break;
+      case -1: // end of buffer
+          break;
+      default:
+          CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s file.",
+              cmd_num,block_buf,config_textname);
+          break;
+      }
+      skip_conf_to_next_line(buf,&pos,len);
+    }
+#undef COMMAND_TEXT
+  }
+  return true;
+}
+
+TbBool load_magic_config_file(const char *textname, const char *fname, unsigned short flags)
+{
+    char *buf;
+    long len;
+    TbBool result;
+    SYNCDBG(0,"%s %s file \"%s\".",((flags & CnfLd_ListOnly) == 0)?"Reading":"Parsing",textname,fname);
+    len = LbFileLengthRnc(fname);
+    if (len < MIN_CONFIG_FILE_SIZE)
+    {
+        if ((flags & CnfLd_IgnoreErrors) == 0)
+            WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
+        return false;
+    }
+    if (len > MAX_CONFIG_FILE_SIZE)
+    {
+        if ((flags & CnfLd_IgnoreErrors) == 0)
+            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
+        return false;
+    }
+    buf = (char *)LbMemoryAlloc(len+256);
+    if (buf == NULL)
+        return false;
+    // Loading file data
+    len = LbFileLoadAt(fname, buf);
+    result = (len > 0);
+    // Parse blocks of the config file
+    if (result)
+    {
+        result = parse_magic_common_blocks(buf, len, textname, flags);
+        if ((flags & CnfLd_AcceptPartial) != 0)
+            result = true;
+        if (!result)
+            WARNMSG("Parsing %s file \"%s\" common blocks failed.",textname,fname);
+    }
+    if (result)
+    {
+        result = parse_magic_spell_blocks(buf, len, textname, flags);
+        if ((flags & CnfLd_AcceptPartial) != 0)
+            result = true;
+        if (!result)
+            WARNMSG("Parsing %s file \"%s\" spell blocks failed.",textname,fname);
+    }
+    if (result)
+    {
+        result = parse_magic_shot_blocks(buf, len, textname, flags);
+        if ((flags & CnfLd_AcceptPartial) != 0)
+            result = true;
+        if (!result)
+            WARNMSG("Parsing %s file \"%s\" shot blocks failed.",textname,fname);
+    }
+    if (result)
+    {
+      result = parse_magic_power_blocks(buf, len, textname, flags);
+      if ((flags & CnfLd_AcceptPartial) != 0)
+          result = true;
+      if (!result)
+          WARNMSG("Parsing %s file \"%s\" power blocks failed.",textname,fname);
+    }
+    if (result)
+    {
+      result = parse_magic_special_blocks(buf, len, textname, flags);
+      if ((flags & CnfLd_AcceptPartial) != 0)
+          result = true;
+      if (!result)
+          WARNMSG("Parsing %s file \"%s\" special blocks failed.",textname,fname);
+    }
+    //Freeing and exiting
+    LbMemoryFree(buf);
+    return result;
+}
+
+TbBool load_magic_config(const char *conf_fname, unsigned short flags)
+{
+    static const char config_global_textname[] = "global magic config";
+    static const char config_campgn_textname[] = "campaign magic config";
+    char *fname;
+    TbBool result;
+    fname = prepare_file_path(FGrp_FxData,conf_fname);
+    result = load_magic_config_file(config_global_textname,fname,flags);
+    fname = prepare_file_path(FGrp_CmpgConfig,conf_fname);
+    if (strlen(fname) > 0)
+    {
+        load_magic_config_file(config_campgn_textname,fname,flags|CnfLd_AcceptPartial|CnfLd_IgnoreErrors);
+    }
+    //Freeing and exiting
+    return result;
+}
+
+/**
+ * Returns Code Name (name to use in script file) of given spell model.
+ */
+const char *spell_code_name(SpellKind spmodel)
+{
+    const char *name;
+    name = get_conf_parameter_text(spell_desc,spmodel);
+    if (name[0] != '\0')
+        return name;
+    return "INVALID";
+}
+
+/**
+ * Returns Code Name (name to use in script file) of given shot model.
+ */
+const char *shot_code_name(ThingModel tngmodel)
+{
+    const char *name;
+    name = get_conf_parameter_text(shot_desc,tngmodel);
+    if (name[0] != '\0')
+        return name;
+    return "INVALID";
+}
+
+/**
+ * Returns Code Name (name to use in script file) of given keepers power kind.
+ */
+const char *power_code_name(PowerKind pwkind)
+{
+    const char *name;
+    name = get_conf_parameter_text(power_desc,pwkind);
+    if (name[0] != '\0')
+        return name;
+    return "INVALID";
+}
+
+/**
+ * Returns the power model identifier for a given code name (found in script file).
+ * Linear running time.
+ * @param code_name
+ * @return A positive integer for the power model if found, otherwise -1
+ */
+int power_model_id(const char * code_name)
+{
+    int i;
+    for (i = 0; i < magic_conf.power_types_count; ++i)
+    {
+        if (strncmp(magic_conf.power_cfgstats[i].code_name, code_name,
+                COMMAND_WORD_LEN) == 0) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+/**
+ * Adds given power to players available powers.
+ *
+ * @param pwkind
+ * @param plyr_idx
+ * @return
+ * @note originally add_spell_to_player()
+ */
+TbBool add_power_to_player(PowerKind pwkind, PlayerNumber plyr_idx)
+{
+    struct Dungeon *dungeon;
+    long i;
+    if ((pwkind < 0) || (pwkind >= KEEPER_POWERS_COUNT))
+    {
+        ERRORLOG("Can't add incorrect power %d to player %d",(int)pwkind, (int)plyr_idx);
+        return false;
+    }
+    dungeon = get_dungeon(plyr_idx);
+    if (dungeon_invalid(dungeon))
+    {
+        ERRORLOG("Can't add %s to player %d which has no dungeon",power_code_name(pwkind), (int)plyr_idx);
+        return false;
+    }
+    i = dungeon->magic_level[pwkind];
+    if (i >= 255)
+    {
+        ERRORLOG("Power %s has bad magic_level=%d for player %d, reset", power_code_name(pwkind), (int)i, (int)plyr_idx);
+        i = 0;
+    }
+    dungeon->magic_level[pwkind] = i+1;
+    dungeon->magic_resrchable[pwkind] = 1;
+    return true;
+}
+
+void remove_power_from_player(PowerKind pwkind, PlayerNumber plyr_idx)
+{
+    struct Dungeon *dungeon;
+    long i;
+    dungeon = get_dungeon(plyr_idx);
+    if (dungeon_invalid(dungeon))
+    {
+        ERRORLOG("Cannot remove spell %s from invalid dungeon %d!",power_code_name(pwkind),(int)plyr_idx);
+        return;
+    }
+    i = dungeon->magic_level[pwkind];
+    if (i < 1)
+    {
+        ERRORLOG("Cannot remove spell %s (%d) from player %d as he doesn't have it!",power_code_name(pwkind),(int)pwkind,(int)plyr_idx);
+        return;
+    }
+    SYNCDBG(4,"Decreasing spell %s of player %d to level %d",power_code_name(pwkind),(int)plyr_idx,(int)i-1);
+    dungeon->magic_level[pwkind] = i-1;
+    switch (pwkind)
+    {
+    case PwrK_OBEY:
+        if (player_uses_power_obey(plyr_idx))
+            turn_off_power_obey(plyr_idx);
+        break;
+    case PwrK_SIGHT:
+        if (player_uses_power_sight(plyr_idx))
+            turn_off_power_sight_of_evil(plyr_idx);
+        break;
+    case PwrK_CALL2ARMS:
+        if (player_uses_power_call_to_arms(plyr_idx))
+            turn_off_power_call_to_arms(plyr_idx);
+        break;
+    }
+    if (game.chosen_spell_type == pwkind)
+    {
+        set_chosen_power_none();
+    }
+}
+
+/**
+ * Zeroes all the costs for all spells.
+ */
+TbBool make_all_powers_cost_free(void)
+{
+  struct MagicStats *pwrdynst;
+  long i,n;
+  for (i=0; i < magic_conf.power_types_count; i++)
+  {
+      pwrdynst = get_power_dynamic_stats(i);
+      for (n=0; n < MAGIC_OVERCHARGE_LEVELS; n++)
+          pwrdynst->cost[n] = 0;
+  }
+  return true;
+}
+
+/**
+ * Makes all keeper spells to be available to research.
+ */
+TbBool make_all_powers_researchable(PlayerNumber plyr_idx)
+{
+    struct Dungeon *dungeon;
+    long i;
+    dungeon = get_players_num_dungeon(plyr_idx);
+    for (i=0; i < KEEPER_POWERS_COUNT; i++)
+    {
+        dungeon->magic_resrchable[i] = 1;
+    }
+    return true;
+}
+
+/**
+ * Sets power availability state.
+ */
+TbBool set_power_available(PlayerNumber plyr_idx, PowerKind pwkind, long resrch, long avail)
+{
+    struct Dungeon *dungeon;
+    SYNCDBG(8,"Starting for power %d, player %d, state %ld,%ld",(int)pwkind,(int)plyr_idx,resrch,avail);
+    // note that we can't get_players_num_dungeon() because players
+    // may be uninitialized yet when this is called.
+    dungeon = get_dungeon(plyr_idx);
+    if (dungeon_invalid(dungeon)) {
+        ERRORDBG(11,"Cannot set trap availability; player %d has no dungeon",(int)plyr_idx);
+        return false;
+    }
+    dungeon->magic_resrchable[pwkind] = resrch;
+    if (avail <= 0)
+    {
+        if (is_power_available(plyr_idx, pwkind))
+            remove_power_from_player(pwkind, plyr_idx);
+        return true;
+    }
+    return add_power_to_player(pwkind, plyr_idx);
+}
+
+/**
+ * Returns if the power can be used by a player.
+ * Checks only if it's available and if the player is 'alive'.
+ * Doesn't check if the player has enough money or map position is on correct spot.
+ */
+TbBool is_power_available(PlayerNumber plyr_idx, PowerKind pwkind)
+{
+    struct Dungeon *dungeon;
+    dungeon = get_players_num_dungeon(plyr_idx);
+    // Check if the player even have a dungeon
+    if (dungeon_invalid(dungeon)) {
+        return false;
+    }
+    //TODO POWERS Mapping child powers to their parent - remove that when magic_level array is enlarged
+    {
+        const struct PowerConfigStats *powerst;
+        powerst = get_power_model_stats(pwkind);
+        if (powerst->parent_power != 0)
+            pwkind = powerst->parent_power;
+    }
+    // Player must have dungeon heart to cast spells, with no heart only floating spirit spell works
+    if (!player_has_heart(plyr_idx) && (pwkind != PwrK_POSSESS)) {
+        return false;
+    }
+    if ((pwkind < 0) || (pwkind >= KEEPER_POWERS_COUNT)) {
+        ERRORLOG("Incorrect power %ld (player %ld)",pwkind, plyr_idx);
+        return false;
+    }
+    if (dungeon->magic_level[pwkind] > 0) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Returns if the power can be or already is obtained by a player.
+ */
+TbBool is_power_obtainable(PlayerNumber plyr_idx, PowerKind pwkind)
+{
+    struct Dungeon *dungeon;
+    dungeon = get_players_num_dungeon(plyr_idx);
+    // Check if the player even have a dungeon
+    if (dungeon_invalid(dungeon)) {
+        return false;
+    }
+    //TODO POWERS Mapping child powers to their parent - remove that when magic_level array is enlarged
+    {
+        const struct PowerConfigStats *powerst;
+        powerst = get_power_model_stats(pwkind);
+        if (powerst->parent_power != 0)
+            pwkind = powerst->parent_power;
+    }
+    // Player must have dungeon heart to cast spells, with no heart only floating spirit spell works
+    if (!player_has_heart(plyr_idx) && (pwkind != PwrK_POSSESS)) {
+        return false;
+    }
+    if ((pwkind < 0) || (pwkind >= KEEPER_POWERS_COUNT)) {
+        ERRORLOG("Incorrect power %ld (player %ld)",pwkind, plyr_idx);
+        return false;
+    }
+    return (dungeon->magic_level[pwkind] > 0) || (dungeon->magic_resrchable[pwkind]);
+}
+
+/**
+ * Makes all the powers, which are researchable, to be instantly available.
+ */
+TbBool make_available_all_researchable_powers(PlayerNumber plyr_idx)
+{
+  struct Dungeon *dungeon;
+  TbBool ret;
+  long i;
+  SYNCDBG(0,"Starting");
+  ret = true;
+  dungeon = get_players_num_dungeon(plyr_idx);
+  if (dungeon_invalid(dungeon)) {
+      ERRORDBG(11,"Cannot do; player %d has no dungeon",(int)plyr_idx);
+      return false;
+  }
+  for (i=0; i < KEEPER_POWERS_COUNT; i++)
+  {
+    if (dungeon->magic_resrchable[i])
+    {
+      ret &= add_power_to_player(i, plyr_idx);
+    }
+  }
+  return ret;
+}
+
+TbBool shot_can_collide_other_shots(ThingModel shotkind)
+{
+    return (shotkind == 2) || (shotkind == 11) || (shotkind == 15);
+}
+/******************************************************************************/

--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -669,6 +669,7 @@ TbBool parse_magic_shot_blocks(char *buf, long len, const char *config_textname,
           shotst->area_range = 0;
           shotst->area_damage = 0;
           shotst->area_blow = 0;
+		  shotst->old->push_on_hit = 0;
       }
   }
   // Load the file
@@ -836,6 +837,8 @@ TbBool parse_magic_shot_blocks(char *buf, long len, const char *config_textname,
 			  k = atoi(word_buf);
 			  shotst->old->push_on_hit = k;
 			  n++;
+			  CONFWRNLOG("hnus read \"%s\" parameter in [%s] block of %s file. --->%d",
+				  COMMAND_TEXT(cmd_num), block_buf, config_textname, shotst->old->push_on_hit);
 		  }
 		  if (n < 1)
 		  {

--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -70,6 +70,7 @@ const struct NamedCommand magic_shot_commands[] = {
   {"AREADAMAGE",      6},
   {"SPEED",           7},
   {"PROPERTIES",      8},
+  {"PUSHONHIT",       9},
   {NULL,              0},
   };
 

--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -829,6 +829,19 @@ TbBool parse_magic_shot_blocks(char *buf, long len, const char *config_textname,
                 break;
             }
           }
+	  case 9: // PUSHONHIT
+		  if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+		  {
+			  k = atoi(word_buf);
+			  shotst->old->push_on_hit = k;
+			  n++;
+		  }
+		  if (n < 1)
+		  {
+			  CONFWRNLOG("Couldn't read \"%s\" parameter in [%s] block of %s file.",
+				  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+		  }
+		  break;
           break;
       case 0: // comment
           break;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -876,9 +876,9 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
     struct ShotConfigStats *shotst;
     struct Coord3d pos2;
     long i,n,amp;
+    shotst = get_shot_model_stats(shotng->model);
 	//amp = shotng->field_20;
 	amp = shotst->old->push_on_hit;
-    shotst = get_shot_model_stats(shotng->model);
     shooter = INVALID_THING;
     if (shotng->parent_idx != shotng->index) {
         shooter = thing_get(shotng->parent_idx);
@@ -988,9 +988,9 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
     }
     if (shotst->old->push_on_hit != 0)
     {
-		amp * (long)shotng->velocity.x.val;
+		i = amp * (long)shotng->velocity.x.val;
 		trgtng->veloc_push_add.x.val += i / 16;
-		amp * (long)shotng->velocity.y.val;
+		i = amp * (long)shotng->velocity.y.val;
 		trgtng->veloc_push_add.y.val += i / 16;
 		trgtng->state_flags |= TF1_PushAdd;
     }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -123,6 +123,7 @@ TbBool detonate_shot(struct Thing *shotng)
         PaletteSetPlayerPalette(myplyr, engine_palette);
         break;
     case ShM_Grenade:
+	case ShM_Firebomb:
         create_effect(&shotng->mappos, TngEff_Unknown50, shotng->owner);
         create_effect(&shotng->mappos,  TngEff_Unknown09, shotng->owner);
         break;
@@ -796,7 +797,8 @@ long melee_shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, stru
     struct CreatureControl *tgcctrl;
     long damage,throw_strength;
     shotst = get_shot_model_stats(shotng->model);
-    throw_strength = shotng->field_20;
+    //throw_strength = shotng->field_20; //this seems to be always 0, this is why it didn't work;
+	throw_strength = shotst->old->push_on_hit;
     if (trgtng->health < 0)
         return 0;
     shooter = INVALID_THING;
@@ -874,7 +876,8 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
     struct ShotConfigStats *shotst;
     struct Coord3d pos2;
     long i,n,amp;
-    amp = shotng->field_20;
+	//amp = shotng->field_20;
+	amp = shotst->old->push_on_hit;
     shotst = get_shot_model_stats(shotng->model);
     shooter = INVALID_THING;
     if (shotng->parent_idx != shotng->index) {
@@ -985,11 +988,11 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
     }
     if (shotst->old->push_on_hit != 0)
     {
-        i = amp * (long)shotng->velocity.x.val;
-        trgtng->veloc_push_add.x.val += i / 16;
-        i = amp * (long)shotng->velocity.y.val;
-        trgtng->veloc_push_add.y.val += i / 16;
-        trgtng->state_flags |= TF1_PushAdd;
+		amp * (long)shotng->velocity.x.val;
+		trgtng->veloc_push_add.x.val += i / 16;
+		amp * (long)shotng->velocity.y.val;
+		trgtng->veloc_push_add.y.val += i / 16;
+		trgtng->state_flags |= TF1_PushAdd;
     }
     create_relevant_effect_for_shot_hitting_thing(shotng, trgtng);
     if (shotst->old->is_boulder != 0)
@@ -1007,6 +1010,9 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
             check_hit_when_attacking_door(trgtng);
         }
     }
+	if (shotst->area_range != 0) detonate_shot(shotng);
+
+
     if (shotst->old->destroy_on_first_hit != 0) {
         delete_thing_structure(shotng, 0);
     }

--- a/thing_shots.c
+++ b/thing_shots.c
@@ -1,0 +1,1408 @@
+/******************************************************************************/
+// Free implementation of Bullfrog's Dungeon Keeper strategy game.
+/******************************************************************************/
+/** @file thing_shots.c
+ *     Shots support functions.
+ * @par Purpose:
+ *     Functions to support shot things.
+ * @par Comment:
+ *     None.
+ * @author   Tomasz Lis
+ * @date     17 Jun 2010 - 07 Jul 2010
+ * @par  Copying and copyrights:
+ *     This program is free software; you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation; either version 2 of the License, or
+ *     (at your option) any later version.
+ */
+/******************************************************************************/
+#include "thing_shots.h"
+
+#include "globals.h"
+#include "bflib_basics.h"
+#include "bflib_memory.h"
+#include "bflib_math.h"
+#include "bflib_sound.h"
+#include "thing_data.h"
+#include "thing_factory.h"
+#include "thing_effects.h"
+#include "thing_physics.h"
+#include "thing_navigate.h"
+#include "thing_objects.h"
+#include "front_simple.h"
+#include "thing_stats.h"
+#include "map_blocks.h"
+#include "room_garden.h"
+#include "config_creature.h"
+#include "config_terrain.h"
+#include "power_process.h"
+#include "gui_topmsg.h"
+#include "gui_soundmsgs.h"
+#include "creature_states.h"
+#include "creature_groups.h"
+#include "game_legacy.h"
+
+#include "keeperfx.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/******************************************************************************/
+DLLIMPORT struct Thing *_DK_get_shot_collided_with_same_type(struct Thing *firstng, struct Coord3d *nxpos);
+/******************************************************************************/
+TbBool thing_is_shot(const struct Thing *thing)
+{
+    if (thing_is_invalid(thing))
+        return false;
+    if (thing->class_id != TCls_Shot)
+        return false;
+    return true;
+}
+
+TbBool shot_is_slappable(const struct Thing *thing, PlayerNumber plyr_idx)
+{
+    struct ShotConfigStats *shotst;
+    if (thing->owner == plyr_idx)
+    {
+        // Normally, thing models 15 and 20 are slappable. But this is up to config file.
+        shotst = get_shot_model_stats(thing->model);
+        return ((shotst->model_flags & ShMF_Slappable) != 0);
+    }
+    return false;
+}
+
+TbBool shot_model_is_navigable(long tngmodel)
+{
+    // Normally, only shot model 6 is navigable
+    struct ShotConfigStats *shotst;
+    shotst = get_shot_model_stats(tngmodel);
+    return ((shotst->model_flags & ShMF_Navigable) != 0);
+}
+
+TbBool shot_is_boulder(const struct Thing *thing)
+{
+    return (thing->model == ShM_Boulder); //TODO CONFIG shot model dependency, make config option instead
+}
+
+TbBool detonate_shot(struct Thing *shotng)
+{
+    struct PlayerInfo *myplyr;
+    struct Thing *castng;
+    struct ShotConfigStats *shotst;
+    shotst = get_shot_model_stats(shotng->model);
+    SYNCDBG(8,"Starting for %s index %d owner %d",thing_model_name(shotng),(int)shotng->index,(int)shotng->owner);
+    castng = INVALID_THING;
+    myplyr = get_my_player();
+    // Identify the creator if the shot
+    if (shotng->index != shotng->parent_idx) {
+        castng = thing_get(shotng->parent_idx);
+        TRACE_THING(castng);
+    }
+    // If the shot has area_range, then make area damage
+    if (shotst->area_range != 0) {
+        struct CreatureStats *crstat;
+        crstat = creature_stats_get_from_thing(castng);
+        //TODO SPELLS Spell level should be taken from within the shot, not from caster creature
+        // Caster may have leveled up, or even may be already dead
+        // But currently shot do not store its level, so we don't really have a choice
+        struct CreatureControl *cctrl;
+        cctrl = creature_control_get_from_thing(castng);
+        long dist, damage;
+        dist = compute_creature_attack_range(shotst->area_range*COORD_PER_STL, crstat->luck, cctrl->explevel);
+        damage = compute_creature_attack_spell_damage(shotst->area_damage, crstat->luck, cctrl->explevel);
+        HitTargetFlags hit_targets;
+        hit_targets = hit_type_to_hit_targets(shotst->area_hit_type);
+        explosion_affecting_area(castng, &shotng->mappos, dist, damage, shotst->area_blow, hit_targets, shotst->damage_type);
+    }
+    //TODO CONFIG shot model dependency, make config option instead
+    switch (shotng->model)
+    {
+    case ShM_Lightning:
+    case ShM_GodLightning:
+    case ShM_GodLightBall:
+        PaletteSetPlayerPalette(myplyr, engine_palette);
+        break;
+    case ShM_Grenade:
+	case ShM_Firebomb:
+        create_effect(&shotng->mappos, TngEff_Unknown50, shotng->owner);
+        create_effect(&shotng->mappos,  TngEff_Unknown09, shotng->owner);
+        break;
+    case ShM_Boulder:
+        create_effect_around_thing(shotng, TngEff_DirtRubble);
+        break;
+    default:
+        break;
+    }
+    delete_thing_structure(shotng, 0);
+    return true;
+}
+
+struct Thing *get_shot_collided_with_same_type_on_subtile(struct Thing *shotng, struct Coord3d *nxpos, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    long i;
+    unsigned long k;
+    const struct Thing *parentng;
+    if (shotng->parent_idx > 0) {
+        parentng = thing_get(shotng->parent_idx);
+    } else {
+        parentng = INVALID_THING;
+    }
+    struct Map *mapblk;
+    mapblk = get_map_block_at(stl_x, stl_y);
+    if (map_block_invalid(mapblk))
+        return INVALID_THING;
+    k = 0;
+    i = get_mapwho_thing_index(mapblk);
+    while (i != 0)
+    {
+        struct Thing *thing;
+        thing = thing_get(i);
+        if (thing_is_invalid(thing))
+        {
+            WARNLOG("Jump out of things array");
+            break;
+        }
+        i = thing->next_on_mapblk;
+        // Per thing code
+        if ((thing->index != shotng->index) && collide_filter_thing_is_of_type(thing, parentng, shotng->class_id, shotng->model))
+        {
+            if (things_collide_while_first_moves_to(shotng, nxpos, thing)) {
+                return thing;
+            }
+        }
+        // Per thing code ends
+        k++;
+        if (k > THINGS_COUNT)
+        {
+            ERRORLOG("Infinite loop detected when sweeping things list");
+            break_mapwho_infinite_chain(mapblk);
+            break;
+        }
+    }
+    return INVALID_THING;
+}
+
+struct Thing *get_shot_collided_with_same_type(struct Thing *shotng, struct Coord3d *nxpos)
+{
+    //return _DK_get_shot_collided_with_same_type(thing, nxpos);
+    MapSubtlCoord stl_x_beg, stl_y_beg;
+    stl_x_beg = coord_subtile(nxpos->x.val - 384);
+    if (stl_x_beg < 0)
+        stl_x_beg = 0;
+    stl_y_beg = coord_subtile(nxpos->y.val - 384);
+    if (stl_y_beg < 0)
+        stl_y_beg = 0;
+    MapSubtlCoord stl_x_end, stl_y_end;
+    stl_x_end = coord_subtile(nxpos->x.val + 384);
+    if (stl_x_end >= map_subtiles_x)
+      stl_x_end = map_subtiles_x;
+    stl_y_end = coord_subtile(nxpos->y.val + 384);
+    if (stl_y_end >= map_subtiles_y)
+      stl_y_end = map_subtiles_y;
+    MapSubtlCoord stl_x, stl_y;
+    for (stl_y = stl_y_beg; stl_y <= stl_y_end; stl_y++)
+    {
+        for (stl_x = stl_x_beg; stl_x <= stl_x_end; stl_x++)
+        {
+            struct Thing *thing;
+            thing = get_shot_collided_with_same_type_on_subtile(shotng, nxpos, stl_x, stl_y);
+            if (!thing_is_invalid(thing)) {
+                return thing;
+            }
+        }
+    }
+    return INVALID_THING;
+}
+
+TbBool give_gold_to_creature_or_drop_on_map_when_digging(struct Thing *creatng, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long damage)
+{
+    struct CreatureControl *cctrl;
+    struct CreatureStats *crstat;
+    struct Dungeon *dungeon;
+    struct SlabMap *slb;
+    long gold;
+    cctrl = creature_control_get_from_thing(creatng);
+    crstat = creature_stats_get_from_thing(creatng);
+    dungeon = get_dungeon(creatng->owner);
+    slb = get_slabmap_for_subtile(stl_x, stl_y);
+    gold = calculate_gold_digged_out_of_slab_with_single_hit(damage, creatng->owner, cctrl->explevel, slb);
+    creatng->creature.gold_carried += gold;
+    if (!dungeon_invalid(dungeon)) {
+        dungeon->lvstats.gold_mined += gold;
+    }
+    if (crstat->gold_hold <= creatng->creature.gold_carried)
+    {
+        drop_gold_pile(creatng->creature.gold_carried, &creatng->mappos);
+        creatng->creature.gold_carried = 0;
+    }
+    return true;
+}
+
+void process_dig_shot_hit_wall(struct Thing *thing, unsigned long blocked_flags)
+{
+    MapSubtlCoord stl_x, stl_y;
+    struct Thing *diggertng;
+    unsigned long k;
+    diggertng = INVALID_THING;
+    if (thing->index != thing->parent_idx)
+      diggertng = thing_get(thing->parent_idx);
+    if (!thing_exists(diggertng))
+    {
+        ERRORLOG("Digging shot hit wall, but there's no digger creature index %d.",thing->parent_idx);
+        return;
+    }
+    if (blocked_flags & SlbBloF_WalledX)
+    {
+        k = thing->move_angle_xy & 0xFC00;
+        if (k != 0)
+        {
+          stl_x = slab_subtile_center(coord_slab(thing->mappos.x.val) - 1);
+          stl_y = slab_subtile_center(coord_slab(thing->mappos.y.val));
+        }
+        else
+        {
+          stl_x = slab_subtile_center(coord_slab(thing->mappos.x.val) + 1);
+          stl_y = slab_subtile_center(coord_slab(thing->mappos.y.val));
+        }
+    } else
+    if (blocked_flags & SlbBloF_WalledY)
+    {
+        k = thing->move_angle_xy & 0xFE00;
+        if ((k != 0) && (k != 0x0600))
+        {
+          stl_x = slab_subtile_center(coord_slab(thing->mappos.x.val));
+          stl_y = slab_subtile_center(coord_slab(thing->mappos.y.val) + 1);
+        }
+        else
+        {
+          stl_x = slab_subtile_center(coord_slab(thing->mappos.x.val));
+          stl_y = slab_subtile_center(coord_slab(thing->mappos.y.val) - 1);
+        }
+    } else
+    {
+        stl_x = coord_subtile(thing->mappos.x.val);
+        stl_y = coord_subtile(thing->mappos.y.val);
+    }
+    struct SlabMap *slb;
+    slb = get_slabmap_for_subtile(stl_x, stl_y);
+    // You can only dig your own or neutral ground
+    if ((slabmap_owner(slb) != game.neutral_player_num) && (slabmap_owner(slb) != diggertng->owner))
+    {
+        return;
+    }
+    struct Map *mapblk;
+    mapblk = get_map_block_at(stl_x, stl_y);
+    // Doors cannot be digged
+    if ((mapblk->flags & SlbAtFlg_IsDoor) != 0)
+    {
+        return;
+    }
+    if ((mapblk->flags & SlbAtFlg_Blocking) == 0)
+    {
+        return;
+    }
+    int damage;
+    damage = thing->word_14;
+    if ((damage >= slb->health) && !slab_kind_is_indestructible(slb->kind))
+    {
+        if ((mapblk->flags & SlbAtFlg_Valuable) != 0)
+        { // Valuables require counting gold
+            give_gold_to_creature_or_drop_on_map_when_digging(diggertng, stl_x, stl_y, damage);
+            mine_out_block(stl_x, stl_y, diggertng->owner);
+            thing_play_sample(diggertng, 72+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+        } else
+        if ((mapblk->flags & SlbAtFlg_IsDoor) == 0)
+        { // All non-gold and non-door slabs are just destroyed
+            dig_out_block(stl_x, stl_y, diggertng->owner);
+            thing_play_sample(diggertng, 72+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+        }
+        check_map_explored(diggertng, stl_x, stl_y);
+    } else
+    {
+        if (!slab_kind_is_indestructible(slb->kind))
+        {
+            slb->health -= damage;
+        }
+        if ((mapblk->flags & SlbAtFlg_Valuable) != 0)
+        {
+            give_gold_to_creature_or_drop_on_map_when_digging(diggertng, stl_x, stl_y, damage);
+        }
+    }
+}
+
+struct Thing *create_shot_hit_effect(struct Coord3d *effpos, long effowner, long eff_kind, long snd_idx, long snd_range)
+{
+    struct Thing *efftng;
+    long i;
+    efftng = INVALID_THING;
+    if (eff_kind > 0) {
+        efftng = create_effect(effpos, eff_kind, effowner);
+        TRACE_THING(efftng);
+    }
+    if (snd_idx > 0)
+    {
+        if (!thing_is_invalid(efftng))
+        {
+            i = snd_idx;
+            if (snd_range > 1)
+                i += UNSYNC_RANDOM(snd_range);
+            thing_play_sample(efftng, i, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+        }
+    }
+    return efftng;
+}
+
+/**
+ * Processes hitting a wall by given shot.
+ *
+ * @param thing The thing to be moved into wall.
+ * @param pos Next position of the thing.
+ * @return Gives true if the shot hit a wall and was destroyed.
+ *     If the shot wasn't detonated, then the function returns false.
+ * @note This function may delete the thing given in parameter.
+ */
+TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
+{
+    struct ShotConfigStats *shotst;
+    struct Thing *efftng;
+    struct Thing *doortng;
+    unsigned long blocked_flags;
+    TbBool shot_explodes;
+    long i;
+    SYNCDBG(8,"Starting for %s index %d",thing_model_name(shotng),(int)shotng->index);
+
+    efftng = INVALID_THING;
+    shot_explodes = 0;
+    shotst = get_shot_model_stats(shotng->model);
+    blocked_flags = get_thing_blocked_flags_at(shotng, pos);
+    if ( shotst->old->field_49 ) {
+        process_dig_shot_hit_wall(shotng, blocked_flags);
+    }
+
+    // If blocked by a higher wall
+    if ((blocked_flags & SlbBloF_WalledZ) != 0)
+    {
+        long cube_id;
+        cube_id = get_top_cube_at(pos->x.stl.num, pos->y.stl.num, NULL);
+        doortng = get_door_for_position(pos->x.stl.num, pos->y.stl.num);
+        if (!thing_is_invalid(doortng))
+        {
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_door.effect_model, shotst->old->hit_door.sndsample_idx, shotst->old->hit_door.sndsample_range);
+            if (shotst->old->hit_door.destroyed)
+              shot_explodes = 1;
+            i = calculate_shot_real_damage_to_door(doortng, shotng);
+            apply_damage_to_thing(doortng, i, shotst->damage_type, -1);
+        } else
+        if (cube_is_water(cube_id))
+        {
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_water_effect_model, shotst->old->hit_water_sndsample_idx, 1);
+            if (shotst->old->hit_water_destroyed) {
+                shot_explodes = 1;
+            }
+        } else
+        if (cube_is_lava(cube_id))
+        {
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_lava_effect_model, shotst->old->hit_lava_sndsample_idx, 1);
+            if (shotst->old->hit_lava_destroyed) {
+                shot_explodes = 1;
+            }
+        } else
+        {
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_generic.effect_model, shotst->old->hit_generic.sndsample_idx, shotst->old->hit_generic.sndsample_range);
+            if (shotst->old->hit_generic.destroyed) {
+                shot_explodes = 1;
+            }
+        }
+    }
+
+    if ( !shot_explodes )
+    {
+        if ((blocked_flags & (SlbBloF_WalledX|SlbBloF_WalledY)) != 0)
+        {
+            doortng = get_door_for_position(pos->x.stl.num, pos->y.stl.num);
+            if (!thing_is_invalid(doortng))
+            {
+                efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_door.effect_model, shotst->old->hit_door.sndsample_idx, shotst->old->hit_door.sndsample_range);
+                if (shotst->old->hit_door.destroyed)
+                    shot_explodes = 1;
+                i = calculate_shot_real_damage_to_door(doortng, shotng);
+                apply_damage_to_thing(doortng, i, shotst->damage_type, -1);
+            } else
+            {
+                efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_generic.effect_model, shotst->old->hit_generic.sndsample_idx, shotst->old->hit_generic.sndsample_range);
+                if (shotst->old->hit_generic.destroyed)
+                  shot_explodes = 1;
+            }
+        }
+    }
+    if (!thing_is_invalid(efftng)) {
+        efftng->byte_16 = shotst->area_hit_type;
+    }
+    if ( shot_explodes )
+    {
+        return detonate_shot(shotng);
+    }
+    if (shotst->old->field_D <= 0)
+    {
+        slide_thing_against_wall_at(shotng, pos, blocked_flags);
+    } else
+    {
+        bounce_thing_off_wall_at(shotng, pos, blocked_flags);
+    }
+    return false;
+}
+
+/**
+ * Processes hitting a door by given shot.
+ *
+ * @param thing The thing to be moved.
+ * @param pos Next position of the thing.
+ * @return Gives true if the shot hit a door and was destroyed.
+ *     If the shot wasn't detonated, then the function returns false.
+ * @note This function may delete the thing given in parameter.
+ */
+long shot_hit_door_at(struct Thing *shotng, struct Coord3d *pos)
+{
+    struct Thing *efftng;
+    struct ShotConfigStats *shotst;
+    struct Thing *doortng;
+    long blocked_flags;
+    int i,n;
+    TbBool shot_explodes;
+    SYNCDBG(18,"Starting for %s index %d",thing_model_name(shotng),(int)shotng->index);
+    shot_explodes = false;
+    shotst = get_shot_model_stats(shotng->model);
+    efftng = INVALID_THING;
+    blocked_flags = get_thing_blocked_flags_at(shotng, pos);
+    if (blocked_flags != 0)
+    {
+      doortng = get_door_for_position(pos->x.stl.num, pos->y.stl.num);
+      // If we did found a door to hit
+      if (!thing_is_invalid(doortng))
+      {
+          // If the shot hit is supposed to create effect thing
+          n = shotst->old->hit_door.effect_model;
+          if (n > 0) {
+              efftng = create_effect(&shotng->mappos, n, shotng->owner);
+          }
+          // If the shot hit is supposed to create sound
+          n = shotst->old->hit_door.sndsample_idx;
+          if (n > 0)
+          {
+              if (!thing_is_invalid(efftng)) {
+                  i = shotst->old->hit_door.sndsample_range;
+                  thing_play_sample(efftng, n + ACTION_RANDOM(i), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+              }
+          }
+          // Shall the shot be destroyed on impact
+          if (shotst->old->hit_door.destroyed) {
+              shot_explodes = true;
+          }
+          // Apply damage to the door
+          i = calculate_shot_real_damage_to_door(doortng, shotng);
+          apply_damage_to_thing(doortng, i, shotst->damage_type, -1);
+      }
+    }
+    if (!thing_is_invalid(efftng)) {
+        efftng->byte_16 = shotst->area_hit_type;
+    }
+    if ( shot_explodes )
+    {
+        return detonate_shot(shotng);
+    }
+    if (shotst->old->field_D <= 0)
+    {
+        slide_thing_against_wall_at(shotng, pos, blocked_flags);
+    } else
+    {
+        bounce_thing_off_wall_at(shotng, pos, blocked_flags);
+    }
+    return false;
+}
+
+TbBool apply_shot_experience(struct Thing *shooter, long exp_factor, long exp_increase, long shot_model)
+{
+    struct ShotConfigStats *shotst;
+    struct CreatureControl *shcctrl;
+    long exp_mag,exp_gained;
+    if (!creature_can_gain_experience(shooter))
+        return false;
+    shcctrl = creature_control_get_from_thing(shooter);
+    shotst = get_shot_model_stats(shot_model);
+    exp_mag = shotst->old->experience_given_to_shooter;
+    exp_gained = (exp_mag * (exp_factor + 12 * exp_factor * exp_increase / 100) << 8) / 256;
+    shcctrl->prev_exp_points = shcctrl->exp_points;
+    shcctrl->exp_points += exp_gained;
+    if ( check_experience_upgrade(shooter) ) {
+        external_set_thing_state(shooter, CrSt_CreatureBeHappy);
+    }
+    return true;
+}
+
+// originally was apply_shot_experience()
+TbBool apply_shot_experience_from_hitting_creature(struct Thing *shooter, struct Thing *target, long shot_model)
+{
+    struct CreatureStats *tgcrstat;
+    struct CreatureControl *tgcctrl;
+    tgcctrl = creature_control_get_from_thing(target);
+    tgcrstat = creature_stats_get_from_thing(target);
+    return apply_shot_experience(shooter, tgcrstat->exp_for_hitting, tgcctrl->explevel, shot_model);
+}
+
+long shot_kill_object(struct Thing *shotng, struct Thing *target)
+{
+    if (thing_is_dungeon_heart(target))
+    {
+        target->active_state = 3;
+        target->health = -1;
+        if (is_my_player_number(shotng->owner))
+        {
+            struct PlayerInfo *player;
+            player = get_player(target->owner);
+            if (player_exists(player) && (player->field_2C == 1))
+            {
+                output_message(SMsg_DefeatedKeeper, 0, true);
+            }
+        }
+        struct Dungeon *dungeon;
+        dungeon = get_players_num_dungeon(shotng->owner);
+        if (!dungeon_invalid(dungeon)) {
+            dungeon->lvstats.keepers_destroyed++;
+        }
+        return 1;
+    }
+    else
+    if (object_is_growing_food(target))
+    {
+        delete_thing_structure(target, 0);
+    } else
+    if (object_is_mature_food(target))
+    {
+        thing_play_sample(shotng, 112+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+        remove_food_from_food_room_if_possible(target);
+        delete_thing_structure(target, 0);
+    } else
+    {
+        WARNLOG("Killing %s by %s is not supported",thing_model_name(target),thing_model_name(shotng));
+    }
+    return 0;
+}
+
+long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord3d *pos)
+{
+    struct ShotConfigStats *shotst;
+    shotst = get_shot_model_stats(shotng->model);
+    if (!thing_is_object(target)) {
+        return 0;
+    }
+    if (shotst->old->cannot_hit_thing) {
+        return 0;
+    }
+    if (target->health < 0) {
+        return 0;
+    }
+    struct ObjectConfig *objconf;
+    objconf = get_object_model_stats2(target->model);
+    if (objconf->resistant_to_nonmagic && !shotst->old->deals_magic_damage) {
+        return 0;
+    }
+    struct Thing *creatng;
+    creatng = INVALID_THING;
+    if (shotng->parent_idx != shotng->index) {
+        creatng = thing_get(shotng->parent_idx);
+    }
+    if (thing_is_dungeon_heart(target))
+    {
+        if (shotng->model == 21) //TODO CONFIG shot model dependency, make config option instead
+        {
+            thing_play_sample(target, 134+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
+        } else
+        if (shotng->model == 22) //TODO CONFIG shot model dependency, make config option instead
+        {
+            thing_play_sample(target, 144+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
+        }
+        event_create_event_or_update_nearby_existing_event(
+          target->mappos.x.val, target->mappos.y.val,
+          EvKind_HeartAttacked, target->owner, 0);
+        if (is_my_player_number(target->owner)) {
+            output_message(SMsg_HeartUnderAttack, 400, true);
+        }
+    } else
+    {
+        int i;
+        i = shotst->old->hit_sound;
+        if (i > 0) {
+            thing_play_sample(target, i, NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
+        }
+    }
+    if (shotng->word_14)
+    {
+        // Drain allows caster to regain half of damage
+        if (shotst->old->health_drain && thing_is_creature(creatng)) {
+            apply_health_to_thing(creatng, shotng->word_14/2);
+        }
+        apply_damage_to_thing(target, shotng->word_14, shotst->damage_type, -1);
+        target->byte_13 = 20;
+    }
+    create_relevant_effect_for_shot_hitting_thing(shotng, target);
+    if (target->health < 0) {
+        shot_kill_object(shotng, target);
+    }
+    if (shotst->old->destroy_on_first_hit) {
+        delete_thing_structure(shotng, 0);
+    }
+    return 1;
+}
+
+long get_damage_of_melee_shot(const struct Thing *shotng, const struct Thing *target)
+{
+    const struct CreatureStats *tgcrstat;
+    const struct CreatureControl *tgcctrl;
+    long crdefense,hitchance;
+    tgcrstat = creature_stats_get_from_thing(target);
+    tgcctrl = creature_control_get_from_thing(target);
+    crdefense = compute_creature_max_defense(tgcrstat->defense,tgcctrl->explevel);
+    hitchance = ((long)shotng->shot.dexterity - crdefense) / 2;
+    if (hitchance < -96) {
+        hitchance = -96;
+    } else
+    if (hitchance > 96) {
+        hitchance = 96;
+    }
+    if (ACTION_RANDOM(256) < (128+hitchance))
+      return shotng->shot.damage;
+    return 0;
+}
+
+long project_damage_of_melee_shot(long shot_dexterity, long shot_damage, const struct Thing *target)
+{
+    const struct CreatureStats *tgcrstat;
+    const struct CreatureControl *tgcctrl;
+    long crdefense,hitchance;
+    tgcrstat = creature_stats_get_from_thing(target);
+    tgcctrl = creature_control_get_from_thing(target);
+    crdefense = compute_creature_max_defense(tgcrstat->defense,tgcctrl->explevel);
+    hitchance = (shot_dexterity - crdefense) / 2;
+    if (hitchance < -96) {
+        hitchance = -96;
+    } else
+    if (hitchance > 96) {
+        hitchance = 96;
+    }
+    // If we'd return something which rounds to 0, change it to 1. Otherwise, just use hit chance in computations.
+    if (abs(shot_damage) > 256/(128+hitchance))
+        return shot_damage * (128+hitchance)/256;
+    else if (shot_damage > 0)
+        return 1;
+    else if (shot_damage < 0)
+        return -1;
+    return 0;
+}
+
+void create_relevant_effect_for_shot_hitting_thing(struct Thing *shotng, struct Thing *target)
+{
+    struct Thing *efftng;
+    efftng = INVALID_THING;
+    if (target->class_id == TCls_Creature)
+    {
+        switch (shotng->model)
+        {
+        case 1:
+        case 2:
+        case 4:
+            efftng = create_effect(&shotng->mappos, TngEff_Unknown01, shotng->owner);
+            break;
+        case 5:
+            efftng = create_effect(&shotng->mappos, TngEff_Unknown13, shotng->owner);
+            if ( !thing_is_invalid(efftng) ) {
+                efftng->byte_16 = 2;
+            }
+            break;
+        case 6:
+        case 9:
+            efftng = create_effect(&shotng->mappos, TngEff_Unknown08, shotng->owner);
+            break;
+        case 14:
+        case 21:
+        case 22:
+            if (creature_affected_by_spell(target, SplK_Freeze)) {
+                efftng = create_effect(&shotng->mappos, TngEff_Unknown22, shotng->owner);
+            } else
+            if (creature_model_bleeds(target->model)) {
+                efftng = create_effect(&shotng->mappos, TngEff_Unknown06, shotng->owner);
+            }
+            break;
+        }
+    }
+    TRACE_THING(efftng);
+}
+
+long check_hit_when_attacking_door(struct Thing *thing)
+{
+    if (!thing_is_creature(thing))
+    {
+        ERRORLOG("The %s in invalid for this check", thing_model_name(thing));
+        return 0;
+    }
+    struct CreatureControl *cctrl;
+    cctrl = creature_control_get_from_thing(thing);
+    if ((cctrl->combat_flags & CmbtF_DoorFight) != 0)
+    {
+        CrtrStateId crstate;
+        crstate = get_creature_state_besides_move(thing);
+        if (crstate != CrSt_CreatureCombatFlee)
+        {
+            set_start_state(thing);
+            return 1;
+        }
+    }
+    return 1;
+}
+
+/**
+ * Kills a creature with given shot.
+ * @param shotng The shot which is killing the victim creature.
+ * @param creatng The victim creature thing.
+ * @return True if the creature is being killed, false if something have failed.
+ * @note sometimes named shot_kills_creature().
+ */
+TbBool shot_kill_creature(struct Thing *shotng, struct Thing *creatng)
+{
+    struct ShotConfigStats *shotst;
+    struct CreatureControl *cctrl;
+    shotst = get_shot_model_stats(shotng->model);
+    creatng->health = -1;
+    cctrl = creature_control_get_from_thing(creatng);
+    cctrl->shot_model = shotng->model;
+    struct Thing *killertng;
+    CrDeathFlags dieflags;
+    if (shotng->index == shotng->parent_idx) {
+        killertng = INVALID_THING;
+        dieflags = CrDed_DiedInBattle;
+    } else {
+        killertng = thing_get(shotng->parent_idx);
+        dieflags = CrDed_DiedInBattle | (shotst->old->cannot_make_target_unconscious?CrDed_NoUnconscious:0);
+    }
+    // Friendly fire should kill the creature, not knock out
+    if (shotng->owner == creatng->owner) {
+        dieflags |= CrDed_NoUnconscious;
+    }
+    return kill_creature(creatng, killertng, shotng->owner, dieflags);
+}
+
+long melee_shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coord3d *pos)
+{
+    struct Thing *shooter;
+    struct ShotConfigStats *shotst;
+    struct CreatureControl *tgcctrl;
+    long damage,throw_strength;
+    shotst = get_shot_model_stats(shotng->model);
+    //throw_strength = shotng->field_20; //this seems to be always 0, this is why it didn't work;
+	throw_strength = shotst->old->push_on_hit;
+    if (trgtng->health < 0)
+        return 0;
+    shooter = INVALID_THING;
+    if (shotng->parent_idx != shotng->index)
+        shooter = thing_get(shotng->parent_idx);
+    tgcctrl = creature_control_get_from_thing(trgtng);
+    damage = get_damage_of_melee_shot(shotng, trgtng);
+    if (damage != 0)
+    {
+      if (shotst->old->hit_sound > 0)
+      {
+          thing_play_sample(trgtng, shotst->old->hit_sound, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+          play_creature_sound(trgtng, CrSnd_Hurt, 3, 0);
+      }
+      if (!thing_is_invalid(shooter)) {
+          apply_damage_to_thing_and_display_health(trgtng, shotng->shot.damage, shotst->damage_type, shooter->owner);
+      } else {
+          apply_damage_to_thing_and_display_health(trgtng, shotng->shot.damage, shotst->damage_type, -1);
+      }
+      if (shotst->old->field_24 != 0) {
+          tgcctrl->field_B1 = shotst->old->field_24;
+      }
+      if ( shotst->old->push_on_hit )
+      {
+          trgtng->veloc_push_add.x.val += (throw_strength * (long)shotng->velocity.x.val) / 16;
+          trgtng->veloc_push_add.y.val += (throw_strength * (long)shotng->velocity.y.val) / 16;
+          trgtng->state_flags |= TF1_PushAdd;
+      }
+      create_relevant_effect_for_shot_hitting_thing(shotng, trgtng);
+      if (trgtng->health >= 0)
+      {
+          if (trgtng->owner != shotng->owner) {
+              check_hit_when_attacking_door(trgtng);
+          }
+      } else
+      {
+          shot_kill_creature(shotng,trgtng);
+      }
+    }
+    if (shotst->old->destroy_on_first_hit) {
+        delete_thing_structure(shotng, 0);
+    }
+    return 1;
+}
+
+void clear_thing_acceleration(struct Thing *thing)
+{
+    thing->veloc_push_add.x.val = 0;
+    thing->veloc_push_add.y.val = 0;
+    thing->veloc_push_add.z.val = 0;
+}
+
+void set_thing_acceleration_angles(struct Thing *thing, long angle_xy, long angle_yz)
+{
+    struct ComponentVector cvect;
+    thing->move_angle_xy = angle_xy;
+    thing->move_angle_z = angle_yz;
+    angles_to_vector(thing->move_angle_xy, thing->move_angle_z, 256, &cvect);
+    thing->veloc_base.x.val = cvect.x;
+    thing->veloc_base.y.val = cvect.y;
+    thing->veloc_base.z.val = cvect.z;
+}
+
+TbBool shot_model_makes_flesh_explosion(long shot_model)
+{
+    if ((shot_model == ShM_Firebomb) || (shot_model == ShM_GodLightBall))
+        return true;
+    return false;
+}
+
+long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coord3d *pos)
+{
+    struct Thing *shooter;
+    struct Thing *efftng;
+    struct ShotConfigStats *shotst;
+    struct Coord3d pos2;
+    long i,n,amp;
+	//amp = shotng->field_20;
+	amp = shotst->old->push_on_hit;
+    shotst = get_shot_model_stats(shotng->model);
+    shooter = INVALID_THING;
+    if (shotng->parent_idx != shotng->index) {
+        shooter = thing_get(shotng->parent_idx);
+    }
+    // Two fighting creatures gives experience
+    if (thing_is_creature(shooter) && thing_is_creature(trgtng))
+    {
+        apply_shot_experience_from_hitting_creature(shooter, trgtng, shotng->model);
+    }
+    if (shotst->old->is_melee != 0)
+    {
+        return melee_shot_hit_creature_at(shotng, trgtng, pos);
+    }
+    if ((shotst->old->cannot_hit_thing != 0) || (trgtng->health < 0)) {
+        return 0;
+    }
+    if (creature_affected_by_spell(trgtng, SplK_Rebound) && (shotst->old->field_29 == 0))
+    {
+        struct Thing *killertng;
+        killertng = INVALID_THING;
+        if (shotng->index != shotng->parent_idx) {
+            killertng = thing_get(shotng->parent_idx);
+        }
+        if (!thing_is_invalid(killertng))
+        {
+            struct CreatureStats *crstat;
+            crstat = creature_stats_get_from_thing(killertng);
+            pos2.x.val = killertng->mappos.x.val;
+            pos2.y.val = killertng->mappos.y.val;
+            pos2.z.val = crstat->eye_height + killertng->mappos.z.val;
+            clear_thing_acceleration(shotng);
+            set_thing_acceleration_angles(shotng, get_angle_xy_to(&shotng->mappos, &pos2), get_angle_yz_to(&shotng->mappos, &pos2));
+            shotng->parent_idx = trgtng->parent_idx;
+            shotng->owner = trgtng->owner;
+        } else
+        {
+            clear_thing_acceleration(shotng);
+            i = (shotng->move_angle_xy + LbFPMath_PI) & LbFPMath_AngleMask;
+            n = (shotng->move_angle_z + LbFPMath_PI) & LbFPMath_AngleMask;
+            set_thing_acceleration_angles(shotng, i, n);
+            if (trgtng->class_id == TCls_Creature)
+            {
+                shotng->parent_idx = trgtng->parent_idx;
+            }
+        }
+        return 1;
+    }
+    // Immunity to boulders
+    if (shot_is_boulder(shotng))
+    {
+        if ((get_creature_model_flags(trgtng) & CMF_ImmuneToBoulder) != 0)
+        {
+            efftng = create_effect(&trgtng->mappos, TngEff_Unknown14, trgtng->owner);
+            if (!thing_is_invalid(efftng)) {
+                efftng->byte_16 = 8;
+            }
+            shotng->health = -1;
+            return 1;
+        }
+    }
+    if (shotst->old->hit_sound != 0)
+    {
+        play_creature_sound(trgtng, CrSnd_Hurt, 1, 0);
+        thing_play_sample(trgtng, shotst->old->hit_sound, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+    }
+    if (shotng->shot.damage != 0)
+    {
+        if (shotst->old->health_drain) {
+            give_shooter_drained_health(shooter, shotng->shot.damage / 2);
+        }
+        if (!thing_is_invalid(shooter)) {
+            apply_damage_to_thing_and_display_health(trgtng, shotng->shot.damage, shotst->damage_type, shooter->owner);
+        } else {
+            apply_damage_to_thing_and_display_health(trgtng, shotng->shot.damage, shotst->damage_type, -1);
+        }
+    }
+    if (shotst->old->field_24 != 0)
+    {
+        struct CreatureControl *cctrl;
+        cctrl = creature_control_get_from_thing(trgtng);
+        if (cctrl->field_B1 == 0) {
+            cctrl->field_B1 = shotst->old->field_24;
+        }
+    }
+    if (shotst->old->cast_spell_kind != 0)
+    {
+        struct CreatureControl *cctrl;
+        cctrl = creature_control_get_from_thing(shooter);
+        if (!creature_control_invalid(cctrl)) {
+            n = cctrl->explevel;
+        } else {
+            n = 0;
+        }
+        apply_spell_effect_to_thing(trgtng, shotst->old->cast_spell_kind, n);
+    }
+    if (shotst->old->group_with_shooter)
+    {
+        if (thing_is_creature(shooter))
+        {
+            if (get_no_creatures_in_group(shooter) < GROUP_MEMBERS_COUNT) {
+                add_creature_to_group(trgtng, shooter);
+            }
+        } else
+        {
+            WARNDBG(8,"The %s index %d owner %d cannot group; invalid parent",thing_model_name(shotng),(int)shotng->index,(int)shotng->owner);
+        }
+    }
+    if (shotst->old->push_on_hit != 0)
+    {
+		amp * (long)shotng->velocity.x.val;
+		trgtng->veloc_push_add.x.val += i / 16;
+		amp * (long)shotng->velocity.y.val;
+		trgtng->veloc_push_add.y.val += i / 16;
+		trgtng->state_flags |= TF1_PushAdd;
+    }
+    create_relevant_effect_for_shot_hitting_thing(shotng, trgtng);
+    if (shotst->old->is_boulder != 0)
+    {
+        struct CreatureStats *crstat;
+        crstat = creature_stats_get_from_thing(trgtng);
+        shotng->health -= crstat->damage_to_boulder;
+    }
+    if (trgtng->health < 0)
+    {
+        shot_kill_creature(shotng, trgtng);
+    } else
+    {
+        if (trgtng->owner != shotng->owner) {
+            check_hit_when_attacking_door(trgtng);
+        }
+    }
+	if (shotst->area_range != 0) detonate_shot(shotng);
+
+
+    if (shotst->old->destroy_on_first_hit != 0) {
+        delete_thing_structure(shotng, 0);
+    }
+    return 1;
+}
+
+TbBool shot_hit_shootable_thing_at(struct Thing *shotng, struct Thing *target, struct Coord3d *pos)
+{
+    if (!thing_exists(target))
+        return false;
+    if (target->class_id == TCls_Object) {
+        return shot_hit_object_at(shotng, target, pos);
+    }
+    if (target->class_id == TCls_Creature) {
+        return shot_hit_creature_at(shotng, target, pos);
+    }
+    if (target->class_id == TCls_DeadCreature) {
+        //TODO implement shooting dead bodies
+    }
+    if (target->class_id == TCls_Shot) {
+        // On a shot for collision, both shots are destroyed
+        //TODO maybe make both shots explode instead?
+        shotng->health = -1;
+        target->health = -1;
+        return true;
+    }
+    return false;
+}
+
+long collide_filter_thing_is_shootable(const struct Thing *thing, const struct Thing *parntng, long hit_targets, long a4)
+{
+    PlayerNumber shot_owner = -1;
+    if (thing_exists(parntng))
+        shot_owner = parntng->owner;
+    return thing_is_shootable(thing, shot_owner, hit_targets);
+}
+
+struct Thing *get_thing_collided_with_at_satisfying_filter_for_subtile(struct Thing *shotng, struct Coord3d *pos, Thing_Collide_Func filter, long param1, long param2, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct Thing *parntng;
+    parntng = INVALID_THING;
+    if (shotng->parent_idx > 0) {
+        parntng = thing_get(shotng->parent_idx);
+    }
+    struct Thing *thing;
+    struct Map *mapblk;
+    long i;
+    unsigned long k;
+    mapblk = get_map_block_at(stl_x,stl_y);
+    k = 0;
+    i = get_mapwho_thing_index(mapblk);
+    while (i != 0)
+    {
+        thing = thing_get(i);
+        TRACE_THING(thing);
+        if (thing_is_invalid(thing))
+        {
+            ERRORLOG("Jump to invalid thing detected");
+            break;
+        }
+        i = thing->next_on_mapblk;
+        // Per thing code start
+        if (thing->index != shotng->index)
+        {
+            if (filter(thing, parntng, param1, param2))
+            {
+                if (things_collide_while_first_moves_to(shotng, pos, thing)) {
+                    return thing;
+                }
+            }
+        }
+        // Per thing code end
+        k++;
+        if (k > THINGS_COUNT)
+        {
+            ERRORLOG("Infinite loop detected when sweeping things list");
+            break_mapwho_infinite_chain(mapblk);
+            break;
+        }
+    }
+    return false;
+}
+
+struct Thing *get_thing_collided_with_at_satisfying_filter(struct Thing *shotng, struct Coord3d *pos, Thing_Collide_Func filter, long a4, long a5)
+{
+    MapSubtlCoord stl_x_min, stl_y_min;
+    MapSubtlCoord stl_x_max, stl_y_max;
+    {
+        int radius;
+        radius = 384;
+        stl_x_min = coord_subtile(pos->x.val - radius);
+        if (stl_x_min < 0)
+            stl_x_min = 0;
+        stl_y_min = coord_subtile(pos->y.val - radius);
+        if (stl_y_min < 0)
+            stl_y_min = 0;
+        stl_x_max = coord_subtile(pos->x.val + radius);
+        if (stl_x_max > map_subtiles_x)
+            stl_x_max = map_subtiles_x;
+        stl_y_max = coord_subtile(pos->y.val + radius);
+        if (stl_y_max > map_subtiles_y)
+            stl_y_max = map_subtiles_y;
+    }
+    MapSubtlCoord stl_x, stl_y;
+    for (stl_y = stl_y_min; stl_y <= stl_y_max; stl_y++)
+    {
+        for (stl_x = stl_x_min; stl_x <= stl_x_max; stl_x++)
+        {
+            struct Thing *coltng;
+            coltng = get_thing_collided_with_at_satisfying_filter_for_subtile(shotng, pos, filter, a4, a5, stl_x, stl_y);
+            if (!thing_is_invalid(coltng)) {
+                return coltng;
+            }
+        }
+    }
+    return INVALID_THING;
+}
+
+/**
+ * Processes hitting another thing.
+ *
+ * @param shotng The thing to be moved.
+ * @param nxpos Next position of the thing.
+ * @return Gives true if the shot hit something and was destroyed.
+ *     If the shot wasn't detonated, then the function returns false.
+ * @note This function may delete the thing given in parameter.
+ */
+TbBool shot_hit_something_while_moving(struct Thing *shotng, struct Coord3d *nxpos)
+{
+    struct Thing *targetng;
+    SYNCDBG(18,"Starting for %s index %d, hit type %d",thing_model_name(shotng),(int)shotng->index, (int)shotng->shot.hit_type);
+    targetng = INVALID_THING;
+    HitTargetFlags hit_targets;
+    hit_targets = hit_type_to_hit_targets(shotng->shot.hit_type);
+    targetng = get_thing_collided_with_at_satisfying_filter(shotng, nxpos, collide_filter_thing_is_shootable, hit_targets, 0);
+    if (thing_is_invalid(targetng)) {
+        return false;
+    }
+    SYNCDBG(18,"The %s index %d, collided with %s index %d",thing_model_name(shotng),(int)shotng->index,thing_model_name(targetng),(int)targetng->index);
+    if (shot_hit_shootable_thing_at(shotng, targetng, nxpos)) {
+        return true;
+    }
+    return false;
+}
+
+TngUpdateRet move_shot(struct Thing *shotng)
+{
+    struct ShotConfigStats *shotst;
+    struct Coord3d pos;
+    TbBool move_allowed;
+    SYNCDBG(18,"Starting for %s index %d",thing_model_name(shotng),(int)shotng->index);
+    TRACE_THING(shotng);
+
+    move_allowed = get_thing_next_position(&pos, shotng);
+    shotst = get_shot_model_stats(shotng->model);
+    if (!shotst->old->cannot_hit_thing)
+    {
+        if (shot_hit_something_while_moving(shotng, &pos)) {
+            return TUFRet_Deleted;
+        }
+    }
+    if ((shotng->movement_flags & TMvF_Unknown10) != 0)
+    {
+      if ((shotst->old->is_melee) && thing_in_wall_at(shotng, &pos)) {
+          if (shot_hit_door_at(shotng, &pos)) {
+              return TUFRet_Deleted;
+          }
+      }
+    } else
+    {
+      if ((!move_allowed) || thing_in_wall_at(shotng, &pos)) {
+          if (shot_hit_wall_at(shotng, &pos)) {
+              return TUFRet_Deleted;
+          }
+      }
+    }
+    move_thing_in_map(shotng, &pos);
+    return TUFRet_Modified;
+}
+
+TngUpdateRet update_shot(struct Thing *thing)
+{
+    struct ShotConfigStats *shotst;
+    struct PlayerInfo *myplyr;
+    struct PlayerInfo *player;
+    struct Thing *target;
+    struct Coord3d pos1;
+    struct Coord3d pos2;
+    struct CoordDelta3d dtpos;
+    struct ComponentVector cvect;
+    long i;
+    TbBool hit;
+    SYNCDBG(18,"Starting for index %d, model %d",(int)thing->index,(int)thing->model);
+    TRACE_THING(thing);
+    hit = false;
+    shotst = get_shot_model_stats(thing->model);
+    myplyr = get_my_player();
+    if (shotst->old->shot_sound != 0)
+    {
+        if (!S3DEmitterIsPlayingSample(thing->snd_emitter_id, shotst->old->shot_sound, 0))
+            thing_play_sample(thing, shotst->old->shot_sound, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+    }
+    if (shotst->old->field_47)
+        thing->health--;
+    if (thing->health < 0)
+    {
+        hit = true;
+    } else
+    {
+        switch ( thing->model )
+        {
+        case ShM_Firebomb:
+            for (i = 2; i > 0; i--)
+            {
+              pos1.x.val = thing->mappos.x.val - ACTION_RANDOM(127) + 63;
+              pos1.y.val = thing->mappos.y.val - ACTION_RANDOM(127) + 63;
+              pos1.z.val = thing->mappos.z.val - ACTION_RANDOM(127) + 63;
+              create_thing(&pos1, TCls_EffectElem, 1, thing->owner, -1);
+            }
+            break;
+        case ShM_Lightning:
+            if ( lightning_is_close_to_player(myplyr, &thing->mappos) )
+            {
+              if (is_my_player_number(thing->owner))
+              {
+                  player = get_player(thing->owner);
+                  if ((thing->parent_idx != 0) && (myplyr->controlled_thing_idx == thing->parent_idx))
+                  {
+                      PaletteSetPlayerPalette(player, lightning_palette);
+                      myplyr->field_3 |= Pf3F_Unkn08;
+                  }
+              }
+            }
+            break;
+        case ShM_NaviMissile:
+            target = thing_get(thing->shot.target_idx);
+            if ((thing_exists(target)) && (target->class_id == TCls_Creature))
+            {
+                pos2.x.val = target->mappos.x.val;
+                pos2.y.val = target->mappos.y.val;
+                pos2.z.val = target->mappos.z.val;
+                pos2.z.val += (target->clipbox_size_yz >> 1);
+                thing->move_angle_xy = get_angle_xy_to(&thing->mappos, &pos2);
+                thing->move_angle_z = get_angle_yz_to(&thing->mappos, &pos2);
+                angles_to_vector(thing->move_angle_xy, thing->move_angle_z, shotst->old->speed, &cvect);
+                dtpos.x.val = cvect.x - thing->veloc_base.x.val;
+                dtpos.y.val = cvect.y - thing->veloc_base.y.val;
+                dtpos.z.val = cvect.z - thing->veloc_base.z.val;
+                cvect.x = dtpos.x.val;
+                cvect.y = dtpos.y.val;
+                cvect.z = dtpos.z.val;
+                i = LbSqrL(dtpos.x.val*(long)dtpos.x.val + dtpos.y.val*(long)dtpos.y.val + dtpos.z.val*(long)dtpos.z.val);
+                if (i > 128)
+                {
+                  dtpos.x.val = ((long)cvect.x << 7) / i;
+                  dtpos.y.val = ((long)cvect.y << 7) / i;
+                  dtpos.z.val = ((long)cvect.z << 7) / i;
+                  cvect.x = dtpos.x.val;
+                  cvect.y = dtpos.y.val;
+                  cvect.z = dtpos.z.val;
+                }
+                thing->veloc_push_add.x.val += cvect.x;
+                thing->veloc_push_add.y.val += cvect.y;
+                thing->veloc_push_add.z.val += cvect.z;
+                thing->state_flags |= TF1_PushAdd;
+            }
+            break;
+        case ShM_Wind:
+            for (i = 10; i > 0; i--)
+            {
+              pos1.x.val = thing->mappos.x.val - ACTION_RANDOM(1023) + 511;
+              pos1.y.val = thing->mappos.y.val - ACTION_RANDOM(1023) + 511;
+              pos1.z.val = thing->mappos.z.val - ACTION_RANDOM(1023) + 511;
+              create_thing(&pos1, TCls_EffectElem, 12, thing->owner, -1);
+            }
+            affect_nearby_enemy_creatures_with_wind(thing);
+            break;
+        case ShM_Grenade:
+            thing->move_angle_xy = (thing->move_angle_xy + LbFPMath_PI/9) & LbFPMath_AngleMask;
+            break;
+        case ShM_Boulder:
+        case ShM_SolidBoulder:
+            if (apply_wallhug_force_to_boulder(thing))
+              hit = true;
+            break;
+        case ShM_GodLightning:
+            draw_god_lightning(thing);
+            lightning_modify_palette(thing);
+            break;
+        case ShM_Vortex:
+            affect_nearby_stuff_with_vortex(thing);
+            break;
+        case ShM_Alarm:
+            affect_nearby_friends_with_alarm(thing);
+            break;
+        case ShM_GodLightBall:
+            update_god_lightning_ball(thing);
+            break;
+        case ShM_TrapLightning:
+            if (((game.play_gameturn - thing->creation_turn) % 16) == 0)
+            {
+              thing->shot.byte_19 = 5;
+              god_lightning_choose_next_creature(thing);
+              target = thing_get(thing->shot.target_idx);
+              if (thing_exists(target))
+              {
+                  shotst = get_shot_model_stats(ShM_GodLightBall);
+                  draw_lightning(&thing->mappos,&target->mappos, 96, 60);
+                  apply_damage_to_thing_and_display_health(target, shotst->old->damage, shotst->damage_type, thing->owner);
+              }
+            }
+            break;
+        default:
+            // All shots that do not require special processing
+            break;
+        }
+    }
+    if (!thing_exists(thing)) {
+        WARNLOG("Thing disappeared during update");
+        return TUFRet_Deleted;
+    }
+    if (hit) {
+        detonate_shot(thing);
+        return TUFRet_Deleted;
+    }
+    return move_shot(thing);
+}
+
+struct Thing *create_shot(struct Coord3d *pos, unsigned short model, unsigned short owner)
+{
+    struct ShotConfigStats *shotst;
+    struct InitLight ilght;
+    struct Thing *thing;
+    if ( !i_can_allocate_free_thing_structure(FTAF_FreeEffectIfNoSlots) )
+    {
+        ERRORDBG(3,"Cannot create shot %d for player %d. There are too many things allocated.",(int)model,(int)owner);
+        erstat_inc(ESE_NoFreeThings);
+        return INVALID_THING;
+    }
+    shotst = get_shot_model_stats(model);
+    thing = allocate_free_thing_structure(FTAF_FreeEffectIfNoSlots);
+    if (thing->index == 0) {
+        ERRORDBG(3,"Should be able to allocate shot %d for player %d, but failed.",(int)model,(int)owner);
+        erstat_inc(ESE_NoFreeThings);
+        return INVALID_THING;
+    }
+    thing->creation_turn = game.play_gameturn;
+    thing->class_id = TCls_Shot;
+    thing->model = model;
+    memcpy(&thing->mappos,pos,sizeof(struct Coord3d));
+    thing->parent_idx = thing->index;
+    thing->owner = owner;
+    thing->field_22 = shotst->old->field_D;
+    thing->field_20 = shotst->old->field_F;
+    thing->field_21 = shotst->old->field_10;
+    thing->field_23 = shotst->old->field_11;
+    thing->field_24 = shotst->old->field_12;
+    thing->movement_flags ^= (thing->movement_flags ^ TMvF_Unknown08 * shotst->old->field_13) & TMvF_Unknown08;
+    set_thing_draw(thing, shotst->old->sprite_anim_idx, 256, shotst->old->sprite_size_max, 0, 0, 2);
+    thing->field_4F ^= (thing->field_4F ^ 0x02 * shotst->old->field_6) & TF4F_Unknown02;
+    thing->field_4F ^= thing->field_4F ^ ((thing->field_4F ^ TF4F_Unknown10 * shotst->old->field_8) & (TF4F_Unknown10|TF4F_Unknown20));
+    thing->field_4F ^= (thing->field_4F ^ shotst->old->field_7) & TF4F_Unknown01;
+    thing->clipbox_size_xy = shotst->old->size_xy;
+    thing->clipbox_size_yz = shotst->old->field_B;
+    thing->solid_size_xy = shotst->old->size_xy;
+    thing->field_5C = shotst->old->field_B;
+    thing->shot.damage = shotst->old->damage;
+    thing->shot.dexterity = 255;
+    thing->health = shotst->health;
+    if (shotst->old->field_50)
+    {
+        LbMemorySet(&ilght, 0, sizeof(struct InitLight));
+        memcpy(&ilght.mappos,&thing->mappos,sizeof(struct Coord3d));
+        ilght.field_0 = shotst->old->field_50;
+        ilght.field_2 = shotst->old->field_52;
+        ilght.is_dynamic = 1;
+        ilght.field_3 = shotst->old->field_53;
+        thing->light_id = light_create_light(&ilght);
+        if (thing->light_id == 0) {
+            // Being out of free lights is quite common - so info instead of warning here
+            SYNCDBG(8,"Cannot allocate dynamic light to %s.",thing_model_name(thing));
+        }
+    }
+    place_thing_in_mapwho(thing);
+    add_thing_to_its_class_list(thing);
+    return thing;
+}
+
+
+/******************************************************************************/
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Shots can now push victim by their impact force related to speed of the shot + multiplier.

cfg example:
----------------------------------------------------
[shot1]
Name = SHOT_FIREBALL
Health = 30
Damage = 30
DamageType = Combustion
HitType = 2
AreaDamage = 0 0 0
Speed = 190
PushOnHit = 2 <- the multiplier
----------------------------------------------------

Firebomb (and any other area-damage shot) now explodes and causes area damage (damage + blow) on impact with units.
Be careful! The area damage is now applied together with normal shot damage.