### PR TITLE
Grenade for creatures

### DIFF
--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1334,7 +1334,7 @@ TngUpdateRet update_shot(struct Thing *thing)
             }
             else
             {
-                struct Coord3d target_pos;
+
                 target_pos.x.val = thing->price.number;
                 target_pos.y.val = thing->shot.byte_19 * 300;
                 target_pos.z.val = target->mappos.z.val;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1334,7 +1334,7 @@ TngUpdateRet update_shot(struct Thing *thing)
             }
             else
             {
-
+                struct Coord3d target_pos;
                 target_pos.x.val = thing->price.number;
                 target_pos.y.val = thing->shot.byte_19 * 300;
                 target_pos.z.val = target->mappos.z.val;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1334,7 +1334,7 @@ TngUpdateRet update_shot(struct Thing *thing)
             }
             else
             {
-		struct Coord3d target_pos;
+                struct Coord3d target_pos;
                 target_pos.x.val = thing->price.number;
                 target_pos.y.val = thing->shot.byte_19 * 300;
                 target_pos.z.val = target->mappos.z.val;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -430,6 +430,18 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     {
         if ((blocked_flags & (SlbBloF_WalledX|SlbBloF_WalledY)) != 0)
         {
+            if (shotng->model == ShM_Grenade)
+            {
+                if (shotng->shot.dexterity >= ACTION_RANDOM(90))
+                {
+                    struct Coord3d target_pos;
+                    target_pos.x.val = shotng->price.number;
+                    target_pos.y.val = shotng->shot.byte_19 * 300;
+                    target_pos.z.val = pos->z.val;
+                    const MapCoordDelta dist = get_2d_distance(pos, &target_pos);
+                    if (dist <= 800) return detonate_shot(shotng);
+                }
+            }
             doortng = get_door_for_position(pos->x.stl.num, pos->y.stl.num);
             if (!thing_is_invalid(doortng))
             {
@@ -1311,6 +1323,24 @@ TngUpdateRet update_shot(struct Thing *thing)
             break;
         case ShM_Grenade:
             thing->move_angle_xy = (thing->move_angle_xy + LbFPMath_PI/9) & LbFPMath_AngleMask;
+            int skill = thing->shot.dexterity;
+            target = thing_get(thing->shot.target_idx);
+            if (thing_is_invalid(target)) break;
+            MapCoordDelta dist;
+            if (skill <= 35)
+            {
+                dist = get_2d_distance(&thing->mappos, &target->mappos);
+                if (dist <= 260) hit = true;
+            }
+            else
+            {
+		struct Coord3d target_pos;
+                target_pos.x.val = thing->price.number;
+                target_pos.y.val = thing->shot.byte_19 * 300;
+                target_pos.z.val = target->mappos.z.val;
+                dist = get_2d_distance(&thing->mappos, &target_pos);
+                if (dist <= 260) hit = true;
+            }
             break;
         case ShM_Boulder:
         case ShM_SolidBoulder:


### PR DESCRIPTION
Let's try out what happens when we give to units the ability to throw grenades with proper timing so it can actually hit the enemy and deal some damage. The throwing accuracy is not perfect. The grenade sometimes explodes too early or behind enemy. This depends on level and dexterity of the creature who is throwing it.

To make it work, some cfgs must be changed:
"CastAtThing" for Grenade spell must be true!

and about SHOT section:
[shot11]
Name = SHOT_GRENADE
Health = 40 ;health might be higher but it's not necessary. needs to be tested out.
Damage = 1
DamageType = Combustion
HitType = 2
AreaDamage = 4 180 70 ; the original values "8 180 255" with the range 8 and blow 255 are quite annoying during battle.
Speed = 95 ;must be slower than the original 128 in order to work properly. 