### PR TITLE
Explosions kill friendlies w/ imprison on

### DIFF
--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -1319,7 +1319,14 @@ TbBool explosion_affecting_thing(struct Thing *tngsrc, struct Thing *tngdst, con
                 }
             } else
             {
-                kill_creature(tngdst, tngsrc, -1, CrDed_DiedInBattle);
+                CrDeathFlags dieflags;
+                dieflags = CrDed_DiedInBattle;
+                // Explosions kill rather than only stun friendly creatures when imprison is on
+                if (tngsrc->owner == tngdst->owner)
+                {
+                    dieflags |= CrDed_NoUnconscious;
+                }
+                kill_creature(tngdst, tngsrc, -1, dieflags);
                 affected = true;
             }
         }


### PR DESCRIPTION
Area damage (due to explosions) that caused damage not from a direct hit used to stun friendly creatures if
imprison was turned on. Now it kills them. Minimally tested with success, using Warlock meteor spell (spell 4 -- hopefully that's the right one) while in possession, indirectly hitting imps.

Please help confirm it's working as expected now.