### PR TITLE
Main keyboard enter key for cheat menu

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -774,6 +774,12 @@ long get_dungeon_control_action_inputs(void)
         if (toggle_main_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
     }
+    // also use the main keyboard enter key for cheat menu
+    if (is_key_pressed(KC_RETURN,KMod_NONE))
+        {
+            if (toggle_main_cheat_menu())
+                clear_key_pressed(KC_RETURN);
+        }
     if (is_key_pressed(KC_F12,KMod_DONTCARE))
     {
         // Note that we're using "close", not "toggle". Menu can't be opened here.
@@ -870,6 +876,12 @@ short get_creature_control_action_inputs(void)
         if (toggle_instance_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
     }
+    // also use the main keyboard enter key for cheat menu
+    if (is_key_pressed(KC_RETURN,KMod_DONTCARE))
+        {
+            if (toggle_main_cheat_menu())
+                clear_key_pressed(KC_RETURN);
+        }
     if (is_key_pressed(KC_F12,KMod_DONTCARE))
     {
         if (toggle_creature_cheat_menu())
@@ -1056,6 +1068,11 @@ short get_map_action_inputs(void)
       {
           if (toggle_main_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
+      }
+      if (is_key_pressed(KC_RETURN,KMod_NONE))
+      {
+          if (toggle_main_cheat_menu())
+            clear_key_pressed(KC_RETURN);
       }
       if ( is_game_key_pressed(Gkey_SwitchToMap, &keycode, false) )
       {

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -879,7 +879,7 @@ short get_creature_control_action_inputs(void)
     // also use the main keyboard enter key (while holding shift) for cheat menu
     if (is_key_pressed(KC_RETURN,KMod_SHIFT))
         {
-            if (toggle_main_cheat_menu())
+            if (toggle_instance_cheat_menu())
                 clear_key_pressed(KC_RETURN);
         }
     if (is_key_pressed(KC_F12,KMod_DONTCARE))

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1069,6 +1069,7 @@ short get_map_action_inputs(void)
           if (toggle_main_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
       }
+      // also use the main keyboard enter key for cheat menu
       if (is_key_pressed(KC_RETURN,KMod_NONE))
       {
           if (toggle_main_cheat_menu())

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -774,8 +774,8 @@ long get_dungeon_control_action_inputs(void)
         if (toggle_main_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
     }
-    // also use the main keyboard enter key for cheat menu
-    if (is_key_pressed(KC_RETURN,KMod_NONE))
+    // also use the main keyboard enter key (while holding shift) for cheat menu
+    if (is_key_pressed(KC_RETURN,KMod_SHIFT))
         {
             if (toggle_main_cheat_menu())
                 clear_key_pressed(KC_RETURN);
@@ -876,8 +876,8 @@ short get_creature_control_action_inputs(void)
         if (toggle_instance_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
     }
-    // also use the main keyboard enter key for cheat menu
-    if (is_key_pressed(KC_RETURN,KMod_DONTCARE))
+    // also use the main keyboard enter key (while holding shift) for cheat menu
+    if (is_key_pressed(KC_RETURN,KMod_SHIFT))
         {
             if (toggle_main_cheat_menu())
                 clear_key_pressed(KC_RETURN);
@@ -1069,8 +1069,8 @@ short get_map_action_inputs(void)
           if (toggle_main_cheat_menu())
             clear_key_pressed(KC_NUMPADENTER);
       }
-      // also use the main keyboard enter key for cheat menu
-      if (is_key_pressed(KC_RETURN,KMod_NONE))
+      // also use the main keyboard enter key (while holding shift) for cheat menu
+      if (is_key_pressed(KC_RETURN,KMod_SHIFT))
       {
           if (toggle_main_cheat_menu())
             clear_key_pressed(KC_RETURN);


### PR DESCRIPTION
Previously, laptops without a numpad could not enable this cheat menu. Using this commonly-used key may or may not be a good idea, but it's consistent with using the main-keyboard +/- buttons for frameskip and if someone has enabled cheats, they aren't going to be surprised that cheats exist by accidentally pressing it during gameplay.

If there's a more fitting key to use for this, let me know.