### PR TITLE
Campaign config player number

### DIFF
--- a/campgns/keeporig.cfg
+++ b/campgns/keeporig.cfg
@@ -39,7 +39,7 @@ OUTRO_MOVIE = outromix.smk
 ; Valid values are: RED, BLUE, GREEN, YELLOW, WHITE
 ; Note that WHITE is added for forward compatibility only - the game is not
 ; playable as the hero player at the moment.
-;HUMAN_PLAYER = RED
+HUMAN_PLAYER = RED
 
 ; Text strings file used for ingame info messages and objectives (not for GUI)
 ; The file can contain up to 1024 strings, separated by null character.

--- a/campgns/keeporig.cfg
+++ b/campgns/keeporig.cfg
@@ -35,6 +35,11 @@ LAND_AMBIENT = 189 190
 ; the files should be placed in MEDIA_LOCATION folder
 ;INTRO_MOVIE =
 OUTRO_MOVIE = outromix.smk
+; Player number to use for human player in this campaing's levels.
+; Valid values are: RED, BLUE, GREEN, YELLOW, WHITE
+; Note that WHITE is added for forward compatibility only - the game is not
+; playable as the hero player at the moment.
+;HUMAN_PLAYER = RED
 
 ; Text strings file used for ingame info messages and objectives (not for GUI)
 ; The file can contain up to 1024 strings, separated by null character.

--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -100,6 +100,7 @@ const struct NamedCommand cmpgn_human_player_options[] = {
   {"BLUE",       1},
   {"GREEN",      2},
   {"YELLOW",     3},
+  {"WHITE",      4},
   {NULL,         0},
   };
 

--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -55,6 +55,7 @@ const struct NamedCommand cmpgn_common_commands[] = {
   {"INTRO_MOVIE",        16},
   {"OUTRO_MOVIE",        17},
   {"LAND_MARKERS",       18},
+  {"HUMAN_PLAYER",       19},
   {NULL,                  0},
   };
 
@@ -92,6 +93,14 @@ const struct NamedCommand cmpgn_map_cmnds_kind[] = {
   {"EXTRA",           LvOp_IsExtra},
   {"FREE",            LvOp_IsFree},
   {NULL,              0},
+  };
+
+const struct NamedCommand cmpgn_human_player_options[] = {
+  {"RED",        0},
+  {"BLUE",       1},
+  {"GREEN",      2},
+  {"YELLOW",     3},
+  {NULL,         0},
   };
 
 /******************************************************************************/
@@ -191,6 +200,7 @@ TbBool clear_campaign(struct GameCampaign *campgn)
   LbMemorySet(campgn->credits_fname,0,DISKPATH_SIZE);
   campgn->credits_data = NULL;
   reset_credits(campgn->credits);
+  campgn->human_player = -1;
   return true;
 }
 
@@ -611,6 +621,16 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
           i = recognize_conf_parameter(buf,&pos,len,cmpgn_level_markers_options);
           if (i >= 0) {
               campgn->land_markers = i;
+              n++;
+          }
+          if (n < 1)
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+          break;
+      case 19: // HUMAN_PLAYER
+          i = recognize_conf_parameter(buf,&pos,len,cmpgn_human_player_options);
+          if (i >= 0) {
+              campgn->human_player = i;
               n++;
           }
           if (n < 1)

--- a/src/config_campaigns.h
+++ b/src/config_campaigns.h
@@ -112,6 +112,8 @@ struct GameCampaign {
   char hiscore_fname[DISKPATH_SIZE];
   struct HighScore *hiscore_table;
   unsigned long hiscore_count;
+  // Human player color
+  short human_player;
 };
 
 struct HighScore {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4153,7 +4153,6 @@ void startup_network_game(TbBool local)
         default_loc_player = campaign.human_player;
         game.local_plyr_idx = default_loc_player;
         my_player_number = default_loc_player;
-        player->field_2C = 1;
     }
     init_level();
     player = get_my_player();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,6 +135,7 @@ unsigned short bf_argc;
 char *bf_argv[CMDLN_MAXLEN+1];
 
 short default_loc_player = 0;
+TbBool force_player_num = false;
 struct StartupParameters start_params;
 
 struct Room *droom = &_DK_game.rooms[25];
@@ -4148,7 +4149,7 @@ void startup_network_game(TbBool local)
     setup_count_players();
     player = get_my_player();
     flgmem = player->field_2C;
-    if (campaign.human_player >= 0)
+    if ((campaign.human_player >= 0) && (!force_player_num))
     {
         default_loc_player = campaign.human_player;
         game.local_plyr_idx = default_loc_player;
@@ -4517,6 +4518,7 @@ short process_command_line(unsigned short argc, char *argv[])
       {
           narg++;
           default_loc_player = atoi(pr2str);
+          force_player_num = true;
       } else
       if (strcasecmp(parstr, "usersfont") == 0)
       {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4146,6 +4146,10 @@ void startup_network_game(TbBool local)
     unsigned int flgmem;
     struct PlayerInfo *player;
     setup_count_players();
+    if (campaign.human_player >= 0)
+    {
+        my_player_number = campaign.human_player;
+    }
     player = get_my_player();
     flgmem = player->field_2C;
     init_level();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4146,12 +4146,15 @@ void startup_network_game(TbBool local)
     unsigned int flgmem;
     struct PlayerInfo *player;
     setup_count_players();
-    if (campaign.human_player >= 0)
-    {
-        my_player_number = campaign.human_player;
-    }
     player = get_my_player();
     flgmem = player->field_2C;
+    if (campaign.human_player >= 0)
+    {
+        default_loc_player = campaign.human_player;
+        game.local_plyr_idx = default_loc_player;
+        my_player_number = default_loc_player;
+        player->field_2C = 1;
+    }
     init_level();
     player = get_my_player();
     player->field_2C = flgmem;


### PR DESCRIPTION
This branch adds a new campaign config option into the common block with the following syntax:
`HUMAN_PLAYER = <RED|BLUE|GREEN|YELLOW>`
If present, this option overrides my_player_number for the campaign levels. Textual definition of the player color instead of just a number is employed as an additional value control step.
