### PR TITLE
Vampires won't go to temple themselves

### DIFF
--- a/src/creature_jobs.c
+++ b/src/creature_jobs.c
@@ -1233,8 +1233,10 @@ TbBool attempt_job_secondary_preference(struct Thing *creatng, long jobpref)
         {
             if (send_creature_to_job_for_player(creatng, creatng->owner, new_job)) 
 			{
-				if (!(creature_dislikes_job(creatng, new_job))){
-                return true; }
+				if (!creature_dislikes_job(creatng, new_job))
+				{
+				    return true;
+				}
             }
         }
     }

--- a/src/creature_jobs.c
+++ b/src/creature_jobs.c
@@ -499,6 +499,13 @@ TbBool creature_will_reject_job(const struct Thing *creatng, CreatureJob jobpref
     return (jobpref & crstat->jobs_not_do) != 0;
 }
 
+TbBool creature_dislikes_job(const struct Thing *creatng, CreatureJob jobpref)
+{
+    struct CreatureStats *crstat;
+    crstat = creature_stats_get_from_thing(creatng);
+    return (jobpref & crstat->jobs_not_do) != 0;
+}
+
 TbBool is_correct_owner_to_perform_job(const struct Thing *creatng, PlayerNumber plyr_idx, CreatureJob new_job)
 {
     // Note that room required for job is not checked here on purpose.
@@ -1224,8 +1231,10 @@ TbBool attempt_job_secondary_preference(struct Thing *creatng, long jobpref)
         CreatureJob new_job = Job_TEMPLE_PRAY;
         if (creature_can_do_job_for_player(creatng, creatng->owner, new_job, JobChk_None))
         {
-            if (send_creature_to_job_for_player(creatng, creatng->owner, new_job)) {
-                return true;
+            if (send_creature_to_job_for_player(creatng, creatng->owner, new_job)) 
+			{
+				if (!(creature_dislikes_job(creatng, new_job))){
+                return true; }
             }
         }
     }


### PR DESCRIPTION
Fixed a bug that caused vampires to occasionally go to the temple to pray with the must_obey spell enabled. Now creatures don't ever go randomly to the temple if they hate praying.

I tested it and it works, but feel free to let me know if there's a more elegant solution to get the same result.