### PR TITLE
Set sound for reinforce wall

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -823,8 +823,8 @@ long instf_reinforce(struct Thing *creatng, long *param)
     if (cctrl->digger.byte_93 <= 25)
     {
         cctrl->digger.byte_93++;
-        if (!S3DEmitterIsPlayingSample(creatng->snd_emitter_id, 172, 0)) {
-            thing_play_sample(creatng, 172, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+        if (!S3DEmitterIsPlayingSample(creatng->snd_emitter_id, 63, 0)) {
+            thing_play_sample(creatng, 63, NORMAL_PITCH, 0, 3, 0, 2, 128);
         }
         return 0;
     }

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1157,7 +1157,7 @@ long food_grows(struct Thing *objtng)
             nobjtng->move_angle_xy = ACTION_RANDOM(0x800);
             nobjtng->food.byte_15 = ACTION_RANDOM(0x6FF);
             nobjtng->food.byte_16 = 0;
-          thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 128);
+          thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 64);
           if (!is_neutral_thing(nobjtng)) {
               struct Dungeon *dungeon;
               dungeon = get_dungeon(nobjtng->owner);

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1157,7 +1157,7 @@ long food_grows(struct Thing *objtng)
             nobjtng->move_angle_xy = ACTION_RANDOM(0x800);
             nobjtng->food.byte_15 = ACTION_RANDOM(0x6FF);
             nobjtng->food.byte_16 = 0;
-          thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 256);
+          thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 128);
           if (!is_neutral_thing(nobjtng)) {
               struct Dungeon *dungeon;
               dungeon = get_dungeon(nobjtng->owner);

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1157,8 +1157,7 @@ long food_grows(struct Thing *objtng)
             nobjtng->move_angle_xy = ACTION_RANDOM(0x800);
             nobjtng->food.byte_15 = ACTION_RANDOM(0x6FF);
             nobjtng->food.byte_16 = 0;
-          //TODO include chick hatching sounds in sound.dat
-          //thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 256);
+          thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 256);
           if (!is_neutral_thing(nobjtng)) {
               struct Dungeon *dungeon;
               dungeon = get_dungeon(nobjtng->owner);

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1157,7 +1157,8 @@ long food_grows(struct Thing *objtng)
             nobjtng->move_angle_xy = ACTION_RANDOM(0x800);
             nobjtng->food.byte_15 = ACTION_RANDOM(0x6FF);
             nobjtng->food.byte_16 = 0;
-          thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 256);
+          //TODO include chick hatching sounds in sound.dat
+          //thing_play_sample(nobjtng, 80 + UNSYNC_RANDOM(3), 100, 0, 3u, 0, 1, 256);
           if (!is_neutral_thing(nobjtng)) {
               struct Dungeon *dungeon;
               dungeon = get_dungeon(nobjtng->owner);


### PR DESCRIPTION
The game tried to play the non-existing sound file 172 when imps would
reinforce walls. This gave errors, and made no sound.
Configured sound 63 to be used instead.