### PR TITLE
Introducing RUN_AFTER_VICTORY script command

### DIFF
--- a/src/game_merge.h
+++ b/src/game_merge.h
@@ -51,6 +51,7 @@ enum GameSystemFlags {
     GSF_CaptureMovie     = 0x0008,
     GSF_CaptureSShot     = 0x0010,
     GSF_AllowOnePlayer   = 0x0040,
+    GSF_RunAfterVictory  = 0x0080,
 };
 
 enum GameGUIFlags {

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -135,6 +135,7 @@ const struct CommandDesc command_desc[] = {
   {"ADD_TO_FLAG",                       "PAN     ", Cmd_ADD_TO_FLAG},
   {"SET_CAMPAIGN_FLAG",                 "PAN     ", Cmd_SET_CAMPAIGN_FLAG},
   {"ADD_TO_CAMPAIGN_FLAG",              "PAN     ", Cmd_ADD_TO_CAMPAIGN_FLAG},
+  {"RUN_AFTER_VICTORY",                 "N       ", Cmd_RUN_AFTER_VICTORY},
   {NULL,                                "        ", Cmd_NONE},
 };
 
@@ -2526,7 +2527,12 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
     case Cmd_ADD_TO_CAMPAIGN_FLAG:
         command_add_to_campaign_flag(scline->np[0], scline->tp[1], scline->np[2]);
         break;
-
+    case Cmd_RUN_AFTER_VICTORY:
+        if (scline->np[0] == 1)
+        {
+            game.system_flags |= GSF_RunAfterVictory;
+        }
+        break;
     default:
         SCRPTERRLOG("Unhandled SCRIPT command '%s'", scline->tcmnd);
         break;

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -115,6 +115,7 @@ enum TbScriptCommands {
     Cmd_ADD_TO_FLAG                       = 95,
     Cmd_SET_CAMPAIGN_FLAG                 = 96,
     Cmd_ADD_TO_CAMPAIGN_FLAG              = 97,
+    Cmd_RUN_AFTER_VICTORY                 = 100,
 };
 
 enum ScriptVariables {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2535,22 +2535,20 @@ void process_dungeons(void)
 void process_level_script(void)
 {
   SYNCDBG(6,"Starting");
-  /* Do NOT stop executing scripts after winning or losing
   struct PlayerInfo *player;
   player = get_my_player();
-  // Do NOT stop executing scripts after a win or a loss
-  if ((game.system_flags & GSF_NetworkActive) == 0)
-  //    && (player->victory_state != VicS_Undecided))
-    return;
-  */
-  process_conditions();
-  process_check_new_creature_partys();
-//script_process_messages(); is not here, but it is in beta - check why
-  process_check_new_tunneller_partys();
-  process_values();
-  process_win_and_lose_conditions(my_player_number); //player->id_number may be uninitialized yet
-//  show_onscreen_msg(8, "Flags %d %d %d %d %d %d", game.dungeon[0].script_flags[0],game.dungeon[0].script_flags[1],
-//    game.dungeon[0].script_flags[2],game.dungeon[0].script_flags[3],game.dungeon[0].script_flags[4],game.dungeon[0].script_flags[5]);
+  // Do NOT stop executing scripts after winning if the RUN_AFTER_VICTORY(1) script command has been issued
+  if ((player->victory_state == VicS_Undecided) || (game.system_flags & GSF_RunAfterVictory))
+  {
+      process_conditions();
+      process_check_new_creature_partys();
+    //script_process_messages(); is not here, but it is in beta - check why
+      process_check_new_tunneller_partys();
+      process_values();
+      process_win_and_lose_conditions(my_player_number); //player->id_number may be uninitialized yet
+    //  show_onscreen_msg(8, "Flags %d %d %d %d %d %d", game.dungeon[0].script_flags[0],game.dungeon[0].script_flags[1],
+    //    game.dungeon[0].script_flags[2],game.dungeon[0].script_flags[3],game.dungeon[0].script_flags[4],game.dungeon[0].script_flags[5]);
+  }
   SYNCDBG(19,"Finished");
 }
 

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -130,7 +130,11 @@ void set_player_as_lost_level(struct PlayerInfo *player)
     struct Thing *thing;
     if (player->victory_state != VicS_Undecided)
     {
-        WARNLOG("Victory state already set to %d",(int)player->victory_state);
+        // Suppress redundant warnings
+        if ((game.system_flags & GSF_RunAfterVictory) == 0)
+        {
+            WARNLOG("Victory state already set to %d",(int)player->victory_state);
+        }
         return;
     }
     SYNCLOG("Player %d lost",(int)player->id_number);


### PR DESCRIPTION
Introducing script command RUN_AFTER_VICTORY which enables the script to run after the player has already won (or lost for that matter).
Example:

`RUN_AFTER_VICTORY(1)`

Arms the script to continue running after victory has been settled. Default value is '0' for backwards compatibility.