### PR TITLE
Adjusted speed of camera movement when frameskip is increased

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1095,6 +1095,15 @@ int global_frameskipTurn = 0;
 
 void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pressed,int speed_pressed)
 {
+    // mouse scroll zoom unaffected by frameskip
+    if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
+    {
+        if (wheel_scrolled_up)
+            set_packet_control(pckt, PCtr_ViewZoomIn);
+        if (wheel_scrolled_down)
+            set_packet_control(pckt, PCtr_ViewZoomOut);
+    }
+
     // Only pan the camera as often as normal despite frameskip
     if (game.frame_skip > 0)
     {
@@ -1107,23 +1116,21 @@ void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pre
         {
             frameskipMax = 3;
         }
-        /**
-        if (game.frame_skip == 1)
+        else if (game.frame_skip > 20 && game.frame_skip < 50)
         {
-            frameskipMax = 1;
+            frameskipMax = (game.frame_skip) / ( log(game.frame_skip) / log(17) );
         }
-        else if (game.frame_skip == 2)
+        else if (game.frame_skip < 200)
         {
-            frameskipMax = 2;
+            frameskipMax = game.frame_skip / ( log(game.frame_skip) / log(10) );
         }
-        else if (game.frame_skip == 4)
+        else if (game.frame_skip == 512) // max frameskip
         {
-            frameskipMax = 4;
+            frameskipMax = 60;
         }
-        */
-        else
+        else // more than 200 but less than 512
         {
-            frameskipMax = game.frame_skip / log10(game.frame_skip);
+            frameskipMax = game.frame_skip / ( log(game.frame_skip) / log(4) );
         }
         TbBool moveTheCamera = (global_frameskipTurn == 0);
         //Checking for evenly distributed camera movement for the various frameskip amounts
@@ -1171,13 +1178,6 @@ void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pre
             pckt->field_10 |= PCAdV_SpeedupPressed;
         }
         set_packet_control(pckt, PCtr_MoveDown);
-    }
-    if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
-    {
-        if (wheel_scrolled_up)
-            set_packet_control(pckt, PCtr_ViewZoomIn);
-        if (wheel_scrolled_down)
-            set_packet_control(pckt, PCtr_ViewZoomOut);
     }
 }
 

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -62,7 +62,6 @@
 
 #include <math.h>
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1089,7 +1088,7 @@ short get_map_action_inputs(void)
     }
 }
 
-// Might want to initiate this in main() and pass a reference to it
+// TODO: Might want to initiate this in main() and pass a reference to it
 // rather than using this global variable. But this works.
 int global_frameskipTurn = 0;
 

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -60,6 +60,9 @@
 #include "keeperfx.hpp"
 #include "KeeperSpeech.h"
 
+#include <math.h>
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1086,8 +1089,50 @@ short get_map_action_inputs(void)
     }
 }
 
+// Might want to initiate this in main() and pass a reference to it
+// rather than using this global variable. But this works.
+int global_frameskipTurn = 0;
+
 void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pressed,int speed_pressed)
 {
+    // Only pan the camera as often as normal despite frameskip
+    if (game.frame_skip > 0)
+    {
+        int frameskipMax = 1;
+        if (game.frame_skip < 4)
+        {
+            frameskipMax = game.frame_skip;
+        }
+        else if (game.frame_skip == 4)
+        {
+            frameskipMax = 3;
+        }
+        /**
+        if (game.frame_skip == 1)
+        {
+            frameskipMax = 1;
+        }
+        else if (game.frame_skip == 2)
+        {
+            frameskipMax = 2;
+        }
+        else if (game.frame_skip == 4)
+        {
+            frameskipMax = 4;
+        }
+        */
+        else
+        {
+            frameskipMax = game.frame_skip / log10(game.frame_skip);
+        }
+        TbBool moveTheCamera = (global_frameskipTurn == 0);
+        //Checking for evenly distributed camera movement for the various frameskip amounts
+        //JUSTMSG("moveTheCamera: %d", moveTheCamera);
+        global_frameskipTurn++;
+        if (global_frameskipTurn > frameskipMax) global_frameskipTurn = 0;
+        if (!moveTheCamera) return;
+    }
+
     long mx,my;
     mx = my_mouse_x;
     my = my_mouse_y;


### PR DESCRIPTION
It's not perfectly all that smooth at higher frameskip values, but at least when using frameskip, the camera doesn't move so quickly. I only changed it for the mouse movement. You can still pan the camera as usual with arrow keys.

My computer doesn't perform well at very high frameskip values, so if you could let me know if it pans too slowly at really high frameskip, I can adjust the calculation for those higher values.