### PR TITLE
Claim & fortify jobs isolated from heart get assigned to imps

### DIFF
--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -1349,10 +1349,9 @@ int add_pretty_and_convert_to_imp_stack(struct Dungeon *dungeon, int max_tasks, 
     slbopt = scratch;
     slblist = (struct SlabCoord *)(scratch + map_tiles_x*map_tiles_y);
     add_pretty_and_convert_to_imp_stack_prepare(dungeon, slbopt);
-    // Add tasks connected to the heart, which are given priority
-    add_pretty_and_convert_to_imp_stack_starting_from_pos(dungeon, slbopt, slblist, &heartng->mappos, &remain_num);
-    // Add (prettying) tasks connected to each imp,
-    // which will only be assigned if jobs connected to heart don't exceed maximum jobs allowed.
+    // Add claiming and fortifying jobs accessible from where the imp is,
+    // rather than from the dungeon heart as previously. This includes isolated areas you drop them into.
+    // "Home isn't necessarily where the Heart is." ~ Wall art decor hanging in every thinking Keeper's kitchen.
     add_pretty_and_convert_to_imp_stack_starting_from_pos(dungeon, slbopt, slblist, &creatng->mappos, &remain_num);
     SYNCDBG(8,"Done, added %d tasks",(int)(max_tasks-remain_num));
     return (max_tasks-remain_num);

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -1327,7 +1327,7 @@ long add_pretty_and_convert_to_imp_stack_starting_from_pos(struct Dungeon *dunge
  * @param max_tasks Max amount of tasks to be added.
  * @return The amount of tasks added.
  */
-int add_pretty_and_convert_to_imp_stack(struct Dungeon *dungeon, int max_tasks)
+int add_pretty_and_convert_to_imp_stack(struct Dungeon *dungeon, int max_tasks, struct Thing *creatng)
 {
     if (dungeon->digger_stack_length >= DIGGER_TASK_MAX_COUNT) {
         WARNLOG("Too many jobs, no place for more");
@@ -1349,7 +1349,11 @@ int add_pretty_and_convert_to_imp_stack(struct Dungeon *dungeon, int max_tasks)
     slbopt = scratch;
     slblist = (struct SlabCoord *)(scratch + map_tiles_x*map_tiles_y);
     add_pretty_and_convert_to_imp_stack_prepare(dungeon, slbopt);
+    // Add tasks connected to the heart, which are given priority
     add_pretty_and_convert_to_imp_stack_starting_from_pos(dungeon, slbopt, slblist, &heartng->mappos, &remain_num);
+    // Add (prettying) tasks connected to each imp,
+    // which will only be assigned if jobs connected to heart don't exceed maximum jobs allowed.
+    add_pretty_and_convert_to_imp_stack_starting_from_pos(dungeon, slbopt, slblist, &creatng->mappos, &remain_num);
     SYNCDBG(8,"Done, added %d tasks",(int)(max_tasks-remain_num));
     return (max_tasks-remain_num);
 }
@@ -2412,13 +2416,14 @@ TbBool imp_stack_update(struct Thing *creatng)
     add_unclaimed_dead_bodies_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/4 - 1);
     add_unclaimed_spells_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/4 - 1);
     add_empty_traps_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/6);
-	add_pretty_and_convert_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/64);
+    // Use imp position to look for tasks as well as from the dungeon heart
+	add_pretty_and_convert_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/64, creatng);
     add_undug_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/16 - 1);
 	add_unclaimed_gold_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/64);
 	add_gems_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT*5/8);
 	add_unclaimed_traps_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/4);
 	add_undug_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT*5/8);
-    add_pretty_and_convert_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT*5/8);
+    add_pretty_and_convert_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT*5/8, creatng);
     add_unclaimed_gold_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT/3);
     add_reinforce_to_imp_stack(dungeon, DIGGER_TASK_MAX_COUNT);
     return true;

--- a/src/spdigger_stack.h
+++ b/src/spdigger_stack.h
@@ -96,7 +96,7 @@ TbBool add_object_for_trap_to_imp_stack(struct Dungeon *dungeon, struct Thing *t
 void setup_imp_stack(struct Dungeon *dungeon);
 int add_undug_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
 int add_gems_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
-int add_pretty_and_convert_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
+int add_pretty_and_convert_to_imp_stack(struct Dungeon *dungeon, int max_tasks, struct Thing *creatng);
 int add_unclaimed_gold_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
 int add_unclaimed_unconscious_bodies_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
 int add_unclaimed_dead_bodies_to_imp_stack(struct Dungeon *dungeon, int max_tasks);

--- a/src/spdigger_stack.h
+++ b/src/spdigger_stack.h
@@ -104,6 +104,9 @@ int add_unclaimed_spells_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
 int add_empty_traps_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
 int add_unclaimed_traps_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
 int add_reinforce_to_imp_stack(struct Dungeon *dungeon, int max_tasks);
+long add_one_pretty_and_convert_to_imp_stack_starting_from_pos(struct Dungeon *dungeon, unsigned char *slbopt, struct SlabCoord *slblist, const struct Coord3d * start_pos, int *remain_num);
+int add_one_pretty_or_convert_per_imp(struct Dungeon *dungeon, int max_tasks, struct Thing *creatng);
+
 
 TbBool imp_will_soon_be_arming_trap(struct Thing *traptng);
 TbBool imp_will_soon_be_working_at_excluding(const struct Thing *creatng, MapSubtlCoord stl_x, MapSubtlCoord stl_y);


### PR DESCRIPTION
Early attempts to fix issue #[680](https://github.com/dkfans/keeperfx/issues/680)

If an imp is isolated from the heart, they should get assignments to claim and fortify available areas (as long as there is a claimed tile to start from), despite them being disconnected from the heart.

Feedback on resulting imp behavior appreciated. Might want to test: 

- Formerly assigned isolated jobs that an imp no longer has access to should not take up space in its list of jobs anymore. I am not sure if these isolated jobs need to be specifically deleted from the job stack or if that will happen automatically.
- Any other special situations or considerations.