### PR TITLE
New sounds for fortifying walls

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -824,7 +824,7 @@ long instf_reinforce(struct Thing *creatng, long *param)
     {
         cctrl->digger.byte_93++;
         if (!S3DEmitterIsPlayingSample(creatng->snd_emitter_id, 63, 0)) {
-            thing_play_sample(creatng, 63, NORMAL_PITCH, 0, 3, 0, 2, 128);
+            thing_play_sample(creatng, 1005 + UNSYNC_RANDOM(7), NORMAL_PITCH, 0, 3, 0, 2, 32);
         }
         return 0;
     }


### PR DESCRIPTION
In 1e0bc3192257d1f55b78de016750ae0f4874a2f1 a fortify sound was introduced, selected from the already included sounds.

This is an update to use newly introduced sound files instead. Therefor it requires an updated sound.dat