### PR TITLE
Number of Music Tracks configurable

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -34,3 +34,6 @@ ATMOS_FREQUENCY=MEDIUM
 
 ; Doubles the width and height of the cinematics.
 RESIZE_MOVIES=ON
+
+; The amount of Music tracks the game can support. Max 50.
+MUSIC_TRACKS=7

--- a/src/config.c
+++ b/src/config.c
@@ -37,12 +37,14 @@
 #include "front_simple.h"
 #include "scrcapt.h"
 #include "vidmode.h"
+#include "music_player.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 /******************************************************************************/
 const char keeper_config_file[]="keeperfx.cfg";
+int max_track = 7;
 
 /**
  * Language 3-char abbreviations.
@@ -109,6 +111,7 @@ const struct NamedCommand conf_commands[] = {
   {"ATMOS_VOLUME",        11},
   {"ATMOS_FREQUENCY",     12},
   {"RESIZE_MOVIES",       13},
+  {"MUSIC_TRACKS",        14},
   {NULL,                   0},
   };
 
@@ -734,6 +737,18 @@ short load_configuration(void)
               features_enabled |= Ft_Resizemovies;
           else
               features_enabled &= ~Ft_Resizemovies;
+          break;
+      case 14: // MUSIC_TRACKS
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            i = atoi(word_buf);
+          }
+          if ((i > 0) && (i <= 50)) {
+              max_track = i;
+          } else {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+          }
           break;
       case 0: // comment
           break;

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -1721,13 +1721,13 @@ void command_set_music(long val)
   {
     SCRPTWRNLOG("Music set inside conditional block; condition ignored");
   }
-  if (val >= FIRST_TRACK && val <= MAX_TRACK)
+  if (val >= FIRST_TRACK && val <= max_track)
   {
     game.audiotrack = val;
   }
   else 
   {
-    SCRPTERRLOG("Invalid music track %d, track must be between %d and %d", val,FIRST_TRACK,MAX_TRACK);
+    SCRPTERRLOG("Invalid music track %d, track must be between %d and %d", val,FIRST_TRACK,max_track);
     return;
   }
 }

--- a/src/music_player.c
+++ b/src/music_player.c
@@ -28,7 +28,8 @@
 extern "C" {
 #endif
 /******************************************************************************/
-Mix_Music* tracks[MAX_TRACK];
+// the 50 is a static value, idealy would be equal to max_track. May not be smaller.
+Mix_Music* tracks[50];
 int current_track;
 /******************************************************************************/
 
@@ -54,7 +55,7 @@ int InitializeMusicPlayer(void)
             tracks[1] = NULL;
             int i;
             // There is no keeper01.ogg. FIRST_TRACK defined as 2.
-            for (i = FIRST_TRACK; i <= MAX_TRACK; i++)
+            for (i = FIRST_TRACK; i <= max_track; i++)
             {
                 const char *fname;
                 fname = prepare_file_fmtpath(FGrp_Music, "keeper%02d.ogg", i);
@@ -91,7 +92,7 @@ void ShutdownMusicPlayer(void)
     }
     Mix_HaltMusic();
     int i;
-    for (i = 0; i < MAX_TRACK; i++)
+    for (i = 0; i < max_track; i++)
     {
         if (tracks[i] != NULL)
         {

--- a/src/music_player.h
+++ b/src/music_player.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 #define FIRST_TRACK 2
-#define MAX_TRACK 7
+extern int max_track;
 
 int InitializeMusicPlayer(void);
 void ShutdownMusicPlayer(void);

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -279,7 +279,7 @@ void update_player_sounds(void)
         process_messages();
         if (!SoundDisabled)
         {
-            if (game.audiotrack >= FIRST_TRACK && game.audiotrack <= MAX_TRACK)
+            if (game.audiotrack >= FIRST_TRACK && game.audiotrack <= max_track)
             {
                 PlayMusicPlayer(game.audiotrack);
             }


### PR DESCRIPTION
Set amount of music tracks in keeperfx.cfg
Can be used in combination with SET_MUSIC command.

MUSIC_TRACKS = 7 is the default, change to any number up to 50.