### PR TITLE
Open/Delete Messages with keyboard shortcut

### DIFF
--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -6195,6 +6195,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "你的工人们制造出了岩浆陷井。"

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6252,6 +6252,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "你的工人已经制造了岩浆陷阱。"

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6490,6 +6490,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Tvi delnici vyvinuli Lavovou past."

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6537,6 +6537,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr "BERICHT AANZETTEN"
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Er is een Lava-val gemaakt."

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -2999,52 +2999,52 @@ msgstr ""
 
 #: guitext:471
 msgctxt "Game controls"
-msgid "UP"
+msgid "Up"
 msgstr ""
 
 #: guitext:472
 msgctxt "Game controls"
-msgid "DOWN"
+msgid "Down"
 msgstr ""
 
 #: guitext:473
 msgctxt "Game controls"
-msgid "LEFT"
+msgid "Left"
 msgstr ""
 
 #: guitext:474
 msgctxt "Game controls"
-msgid "RIGHT"
+msgid "Right"
 msgstr ""
 
 #: guitext:475
 msgctxt "Game controls"
-msgid "ROTATE"
+msgid "Rotate"
 msgstr ""
 
 #: guitext:476
 msgctxt "Game controls"
-msgid "SPEED"
+msgid "Speed"
 msgstr ""
 
 #: guitext:477
 msgctxt "Game controls"
-msgid "ROTATE LEFT"
+msgid "Rotate left"
 msgstr ""
 
 #: guitext:478
 msgctxt "Game controls"
-msgid "ROTATE RIGHT"
+msgid "Rotate right"
 msgstr ""
 
 #: guitext:479
 msgctxt "Game controls"
-msgid "ZOOM IN"
+msgid "Zoom in"
 msgstr ""
 
 #: guitext:480
 msgctxt "Game controls"
-msgid "ZOOM OUT"
+msgid "Zoom out"
 msgstr ""
 
 #: guitext:481
@@ -5693,4 +5693,9 @@ msgstr ""
 msgctxt "In-game interface description"
 msgid ""
 "Health: The maximum amount of health points for this creature."
+msgstr ""
+
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
 msgstr ""

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -3029,22 +3029,22 @@ msgstr ""
 
 #: guitext:477
 msgctxt "Game controls"
-msgid "Rotate left"
+msgid "Rotate Left"
 msgstr ""
 
 #: guitext:478
 msgctxt "Game controls"
-msgid "Rotate right"
+msgid "Rotate Right"
 msgstr ""
 
 #: guitext:479
 msgctxt "Game controls"
-msgid "Zoom in"
+msgid "Zoom In"
 msgstr ""
 
 #: guitext:480
 msgctxt "Game controls"
-msgid "Zoom out"
+msgid "Zoom Out"
 msgstr ""
 
 #: guitext:481

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -6710,6 +6710,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Vos artisans ont fabriqué le piège à LAVE."

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -6736,6 +6736,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr "NACHRICHT WECHSELN"
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Eure Handwerker haben die LAVA-FALLE entwickelt."

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -6600,6 +6600,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "I tuoi artigiani hanno creato la trappola lava."

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6418,6 +6418,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "工房のクリーチャーが溶岩の罠を作った。"

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -5747,3 +5747,8 @@ msgctxt "In-game interface description"
 msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
+
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -5748,3 +5748,8 @@ msgctxt "In-game interface description"
 msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
+
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -6608,6 +6608,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Twoi rzemieślnicy skonstruowali Pułapkę Magmową."

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -6675,3 +6675,7 @@ msgctxt "In-game interface description"
 msgid "Health: The maximum amount of health points for this creature."
 msgstr "Здоровье: Количество очков, которое может быть всего у этого создания."
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6809,6 +6809,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Tus fabricantes han creado la trampa lava."

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6548,6 +6548,11 @@ msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
 
+#: guitext:967
+msgctxt "Menu interface item"
+msgid "Toggle Message"
+msgstr ""
+
 #~ msgctxt "In-game message"
 #~ msgid "Your manufacturers have crafted the Lava Trap."
 #~ msgstr "Dina tillverkare har tagit fram lavafällan."

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -90,6 +90,7 @@ void setup_default_settings(void)
           {KC_BACK, KMod_NONE}, // Gkey_DumpToOldPos
           {KC_P, KMod_NONE},    // Gkey_TogglePause
           {KC_M, KMod_NONE},    // Gkey_SwitchToMap
+          {KC_E, KMod_NONE},    // Gkey_ToggleMessage
      },                         // kbkeys
      1,                         // tooltips_on
      0,                         // first_person_move_invert

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -22,7 +22,7 @@
 #include "globals.h"
 #include "bflib_basics.h"
 
-#define GAME_KEYS_COUNT        32
+#define GAME_KEYS_COUNT        33
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -402,8 +402,9 @@ enum GUIStrings {
     GUIStr_CreatureBestDmgDesc,
     GUIStr_CreatureWeightDesc,
     GUIStr_CreatureScoreDesc = STRINGS_MAX+960,
-	GUIStr_CreatureHealthDesc = STRINGS_MAX+965,
-	GUIStr_CreatureMaxHealthDesc = STRINGS_MAX+966,
+    GUIStr_CreatureHealthDesc = STRINGS_MAX+965,
+    GUIStr_CreatureMaxHealthDesc = STRINGS_MAX+966,
+    GUIStr_ToggleMessage = STRINGS_MAX+967,
 };
 
 enum CampaignStrings {

--- a/src/front_input.h
+++ b/src/front_input.h
@@ -62,6 +62,7 @@ enum GameKeys {
     Gkey_DumpToOldPos,
     Gkey_TogglePause, // 30
     Gkey_SwitchToMap,
+    Gkey_ToggleMessage,
 };
 
 enum TbButtonFrontendFlags {

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -2006,6 +2006,20 @@ void maintain_event_button(struct GuiButton *gbtn)
     {
         // Fight icon flashes when there are fights to show
         gbtn->sprite_idx += 2;
+		long keycode;
+		if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && lbKeyOn[KC_LSHIFT])
+		{
+		    if ((evidx == dungeon->visible_event_idx)) 
+			{
+			clear_key_pressed(keycode);
+	        gui_close_objective(gbtn);
+			}
+			else
+			{
+			clear_key_pressed(keycode);
+			activate_event_box(evidx);
+			}
+		}
     } else
     if (((event->kind == EvKind_Information) || (event->kind == EvKind_QuickInformation))
       && (event->target < 0) && ((game.play_gameturn & 0x01) != 0))

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1987,17 +1987,17 @@ void maintain_event_button(struct GuiButton *gbtn)
     if ((dungeon->visible_event_idx != 0) && (evidx == dungeon->visible_event_idx))
     {
         turn_on_event_info_panel_if_necessary(dungeon->visible_event_idx);
-        if(is_key_pressed(KC_E,KMod_NONE))
+        if (is_game_key_pressed(Gkey_ToggleMessage, &keycode, false))
         {
             gui_kill_event(gbtn);
-            clear_key_pressed(KC_E);
+            clear_key_pressed(keycode);
         }
     }
     else
     {
         if (dungeon->visible_event_idx == 0)
         {
-            if(is_key_pressed(KC_E,KMod_NONE))
+            if (is_game_key_pressed(Gkey_ToggleMessage, &keycode, false))
             {
                 struct Event *evloop;
                 int i = EVENT_BUTTONS_COUNT;
@@ -2011,7 +2011,7 @@ void maintain_event_button(struct GuiButton *gbtn)
                         
                     }
                 }
-                clear_key_pressed(KC_E);
+                clear_key_pressed(keycode);
             }
         }
     }

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1973,6 +1973,7 @@ void maintain_event_button(struct GuiButton *gbtn)
     EventIndex evidx;
     unsigned long evbtn_idx;
     evbtn_idx = (unsigned long)gbtn->content;
+    long keycode;
     if (evbtn_idx <= EVENT_BUTTONS_COUNT)
     {
         evidx = dungeon->event_button_index[evbtn_idx];
@@ -2036,22 +2037,19 @@ void maintain_event_button(struct GuiButton *gbtn)
     {
         // Fight icon flashes when there are fights to show
         gbtn->sprite_idx += 2;
-		long keycode;
-		if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && lbKeyOn[KC_LSHIFT])
-		{
-		    if ((evidx == dungeon->visible_event_idx)) 
-			{
-			clear_key_pressed(keycode);
-			JUSTMSG("TESTLOG: ENOUGH OF THIS SHIT");
-	        gui_close_objective(gbtn);
-			}
-			else
-			{
-			clear_key_pressed(keycode);
-			JUSTMSG("TESTLOG: SHIT IS GOIN DOWN");
-			activate_event_box(evidx);
-			}
-		}
+        if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && lbKeyOn[KC_LSHIFT])
+        {
+            if ((evidx == dungeon->visible_event_idx)) 
+            {
+            clear_key_pressed(keycode);
+            gui_close_objective(gbtn);
+            }
+            else
+            {
+            clear_key_pressed(keycode);
+            activate_event_box(evidx);
+            }
+        }
     } else
     if (((event->kind == EvKind_Information) || (event->kind == EvKind_QuickInformation))
       && (event->target < 0) && ((game.play_gameturn & 0x01) != 0))

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1973,20 +1973,57 @@ void maintain_event_button(struct GuiButton *gbtn)
     EventIndex evidx;
     unsigned long evbtn_idx;
     evbtn_idx = (unsigned long)gbtn->content;
-    if (evbtn_idx <= EVENT_BUTTONS_COUNT) {
+    if (evbtn_idx <= EVENT_BUTTONS_COUNT)
+	{
         evidx = dungeon->event_button_index[evbtn_idx];
-    } else {
+    } 
+	else 
+	{
         evidx = 0;
     }
-
+    struct Event *event;
+    event = &game.event[evidx];
     if ((dungeon->visible_event_idx != 0) && (evidx == dungeon->visible_event_idx))
     {
         turn_on_event_info_panel_if_necessary(dungeon->visible_event_idx);
 		if(is_key_pressed(KC_O,KMod_DONTCARE))
 		{
-		gui_kill_event(gbtn);
+			JUSTMSG("TESTLOG: KILL %d",dungeon->event_button_index[evbtn_idx]);
+			gui_kill_event(gbtn);
+			clear_key_pressed(KC_O);
 		}
     }
+	else
+	{
+	if (dungeon->visible_event_idx == 0)
+	{
+		if(is_key_pressed(KC_I,KMod_DONTCARE))
+		{
+		    struct Event *evloop;
+			//evloop = &game.event[evidx];
+			int i;
+			i = 12;
+			for (i=12; i > 0; i--)
+			{
+				evloop = &game.event[i];
+				JUSTMSG("TESTLOG: event=%d",event->kind);
+				JUSTMSG("TESTLOG: i=%d",i);
+				JUSTMSG("TESTLOG: event button index = %d",dungeon->event_button_index[evbtn_idx]);
+				//if (dungeon->event_button_index[i] == dungeon->visible_event_idx)
+				if(evloop->kind > 0)
+				{
+					JUSTMSG("TESTLOG: found %d with type, activate",i);
+					activate_event_box(i);
+					//gui_open_event(i);
+					break;
+					
+				}
+			}
+			clear_key_pressed(KC_I);
+		}
+	}
+	}
+
 
     if (evidx == 0)
     {
@@ -1998,8 +2035,6 @@ void maintain_event_button(struct GuiButton *gbtn)
       gbtn->tooltip_stridx = GUIStr_Empty;
       return;
     }
-    struct Event *event;
-    event = &game.event[evidx];
     if ((event->kind == EvKind_Objective) && (new_objective))
     {
         activate_event_box(evidx);
@@ -2016,11 +2051,13 @@ void maintain_event_button(struct GuiButton *gbtn)
 		    if ((evidx == dungeon->visible_event_idx)) 
 			{
 			clear_key_pressed(keycode);
+			JUSTMSG("TESTLOG: ENOUGH OF THIS SHIT");
 	        gui_close_objective(gbtn);
 			}
 			else
 			{
 			clear_key_pressed(keycode);
+			JUSTMSG("TESTLOG: SHIT IS GOIN DOWN");
 			activate_event_box(evidx);
 			}
 		}

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1982,6 +1982,10 @@ void maintain_event_button(struct GuiButton *gbtn)
     if ((dungeon->visible_event_idx != 0) && (evidx == dungeon->visible_event_idx))
     {
         turn_on_event_info_panel_if_necessary(dungeon->visible_event_idx);
+		if(is_key_pressed(KC_O,KMod_DONTCARE))
+		{
+		gui_kill_event(gbtn);
+		}
     }
 
     if (evidx == 0)

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1974,11 +1974,11 @@ void maintain_event_button(struct GuiButton *gbtn)
     unsigned long evbtn_idx;
     evbtn_idx = (unsigned long)gbtn->content;
     if (evbtn_idx <= EVENT_BUTTONS_COUNT)
-	{
+    {
         evidx = dungeon->event_button_index[evbtn_idx];
     } 
-	else 
-	{
+    else 
+    {
         evidx = 0;
     }
     struct Event *event;
@@ -1986,43 +1986,34 @@ void maintain_event_button(struct GuiButton *gbtn)
     if ((dungeon->visible_event_idx != 0) && (evidx == dungeon->visible_event_idx))
     {
         turn_on_event_info_panel_if_necessary(dungeon->visible_event_idx);
-		if(is_key_pressed(KC_O,KMod_DONTCARE))
-		{
-			JUSTMSG("TESTLOG: KILL %d",dungeon->event_button_index[evbtn_idx]);
-			gui_kill_event(gbtn);
-			clear_key_pressed(KC_O);
-		}
+        if(is_key_pressed(KC_E,KMod_NONE))
+        {
+            gui_kill_event(gbtn);
+            clear_key_pressed(KC_E);
+        }
     }
-	else
-	{
-	if (dungeon->visible_event_idx == 0)
-	{
-		if(is_key_pressed(KC_I,KMod_DONTCARE))
-		{
-		    struct Event *evloop;
-			//evloop = &game.event[evidx];
-			int i;
-			i = 12;
-			for (i=12; i > 0; i--)
-			{
-				evloop = &game.event[i];
-				JUSTMSG("TESTLOG: event=%d",event->kind);
-				JUSTMSG("TESTLOG: i=%d",i);
-				JUSTMSG("TESTLOG: event button index = %d",dungeon->event_button_index[evbtn_idx]);
-				//if (dungeon->event_button_index[i] == dungeon->visible_event_idx)
-				if(evloop->kind > 0)
-				{
-					JUSTMSG("TESTLOG: found %d with type, activate",i);
-					activate_event_box(i);
-					//gui_open_event(i);
-					break;
-					
-				}
-			}
-			clear_key_pressed(KC_I);
-		}
-	}
-	}
+    else
+    {
+        if (dungeon->visible_event_idx == 0)
+        {
+            if(is_key_pressed(KC_E,KMod_NONE))
+            {
+                struct Event *evloop;
+                int i = EVENT_BUTTONS_COUNT;
+                for (i=EVENT_BUTTONS_COUNT; i > 0; i--)
+                {
+                    evloop = &game.event[i];
+                    if((evloop->kind > 0) && (evloop->owner == my_player_number))
+                    {
+                        activate_event_box(i);
+                        break;
+                        
+                    }
+                }
+                clear_key_pressed(KC_E);
+            }
+        }
+    }
 
 
     if (evidx == 0)

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -75,6 +75,7 @@ const long definable_key_string[] = {
     GUIStr_UndoPickup,
     GUIStr_Pause,
     GUIStr_Map,
+    GUIStr_ToggleMessage,
 };
 /******************************************************************************/
 #ifdef __cplusplus


### PR DESCRIPTION
- Press 'E' to delete any open information/warning message or close an open objective
- Press 'E' to open the newest message you have if there's nothing open
- Added the option to configure this through the options menu. (In all languages, translations required!)
- Press Shift+[Fight] (default F) to open/close the battle menu. (If available)
- A few text tweaks in the 'Define Keys' menu