### PR TITLE
Custom Atmos sound support

### DIFF
--- a/src/bflib_memory.c
+++ b/src/bflib_memory.c
@@ -111,14 +111,15 @@ short update_memory_constraits(void)
   if ( lbMemoryAvailable <= (24*1024*1024) )
       mem_size = 24;
   else
- if ( lbMemoryAvailable <= (32*1024*1024) )
+//  if ( lbMemoryAvailable <= (32*1024*1024) )
       mem_size = 32;
+/*
   else
   if ( lbMemoryAvailable <= (48*1024*1024) )
       mem_size = 48;
   else
       mem_size = 64;
-
+*/
   LbSyncLog("PhysicalMemory %d\n", mem_size);
   return true;
 }

--- a/src/bflib_memory.c
+++ b/src/bflib_memory.c
@@ -111,15 +111,14 @@ short update_memory_constraits(void)
   if ( lbMemoryAvailable <= (24*1024*1024) )
       mem_size = 24;
   else
-//  if ( lbMemoryAvailable <= (32*1024*1024) )
+ if ( lbMemoryAvailable <= (32*1024*1024) )
       mem_size = 32;
-/*
   else
   if ( lbMemoryAvailable <= (48*1024*1024) )
       mem_size = 48;
   else
       mem_size = 64;
-*/
+
   LbSyncLog("PhysicalMemory %d\n", mem_size);
   return true;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -45,6 +45,7 @@ extern "C" {
 /******************************************************************************/
 const char keeper_config_file[]="keeperfx.cfg";
 int max_track = 7;
+TbBool CustomAtmos = false;
 
 /**
  * Language 3-char abbreviations.
@@ -112,6 +113,7 @@ const struct NamedCommand conf_commands[] = {
   {"ATMOS_FREQUENCY",     12},
   {"RESIZE_MOVIES",       13},
   {"MUSIC_TRACKS",        14},
+  {"CUSTOM_ATMOS",	      15},
   {NULL,                   0},
   };
 
@@ -749,6 +751,19 @@ short load_configuration(void)
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
                 COMMAND_TEXT(cmd_num),config_textname);
           }
+          break;
+	  case 15: // Custom atmos
+          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          if (i <= 0)
+          {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+            break;
+          }
+          if (i == 1)
+              CustomAtmos = true;
+		  else
+			  CustomAtmos = false;
           break;
       case 0: // comment
           break;

--- a/src/config.h
+++ b/src/config.h
@@ -166,6 +166,8 @@ struct NetLevelDesc { // sizeof = 14
   char *text;
 };
 
+extern TbBool CustomAtmos;
+
 /******************************************************************************/
 DLLIMPORT extern float _DK_phase_of_moon;
 #define phase_of_moon _DK_phase_of_moon

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -326,7 +326,14 @@ void update_player_sounds(void)
                     // No atmos sounds the first 3 minutes
                     if (game.play_gameturn > 3600)
                     {
+						if (CustomAtmos == true)
+						{
+						play_atmos_sound(1035 + UNSYNC_RANDOM(samples_in_bank - 1035));	
+						}
+						else
+						{
                         play_atmos_sound(1014 + UNSYNC_RANDOM(21));
+						}
                     }
                 } else
                 {


### PR DESCRIPTION
Custom Atmos sound support (append files to sound.dat). Enabled/disabled with a keeperfx.cfg setting.