### PR TITLE
Units can now sleep/eat during CTA

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -4315,7 +4315,7 @@ TbBool external_set_thing_state_f(struct Thing *thing, CrtrStateId state, const 
 
 TbBool creature_free_for_sleep(const struct Thing *thing,  CrtrStateId state)
 {
-    if (creature_affected_by_slap(thing) || creature_affected_by_call_to_arms(thing))
+    if (creature_affected_by_slap(thing) || creature_is_called_to_arms(thing))
         return false;
     return can_change_from_state_to(thing, thing->active_state, state);
 }
@@ -4452,7 +4452,7 @@ long process_creature_needs_a_wage(struct Thing *thing, const struct CreatureSta
 char creature_free_for_lunchtime(struct Thing *creatng)
 {
     return !creature_affected_by_slap(creatng)
-        && !creature_affected_by_call_to_arms(creatng)
+        && !creature_is_called_to_arms(creatng)
         && !creature_affected_by_spell(creatng, SplK_Chicken)
         && can_change_from_state_to(creatng, creatng->active_state, CrSt_CreatureToGarden);
 }

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -342,7 +342,6 @@ TbBool creature_is_actually_scared(const struct Thing *creatng, const struct Thi
     if (creatng->health < (fear * (long long)crmaxhealth) / 1000)
     {
         SYNCDBG(8,"The %s index %d is scared due to low health (%ld/%ld)",thing_model_name(creatng),(int)creatng->index,(long)creatng->health,crmaxhealth);
-        //reset_creature_if_affected_by_cta(creatng);
         return true;
     }
     // If the enemy is way stronger, a creature may be scared anyway

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -86,35 +86,35 @@ const CombatState combat_door_state[] = {
 };
 
 const struct CombatWeapon ranged_offensive_weapon[] = {
-    {CrInst_FREEZE,            156, LONG_MAX},
-	{CrInst_FEAR,              156, LONG_MAX},
-	{CrInst_CAST_SPELL_DISEASE,	 	156, LONG_MAX},
-	{CrInst_CAST_SPELL_CHICKEN,	 	156, LONG_MAX},
-	{CrInst_CAST_SPELL_TIME_BOMB,	768, LONG_MAX},
-    {CrInst_FIRE_BOMB,         768, LONG_MAX},
-    {CrInst_LIGHTNING,         768, LONG_MAX},
-    {CrInst_HAILSTORM,         156, LONG_MAX},
-    {CrInst_POISON_CLOUD,      156, LONG_MAX},
-    {CrInst_DRAIN,             156, LONG_MAX},
-    {CrInst_SLOW,              156, LONG_MAX},
-    {CrInst_NAVIGATING_MISSILE,156, LONG_MAX},
-    {CrInst_MISSILE,           156, LONG_MAX},
-    {CrInst_FIREBALL,          156, LONG_MAX},
-    {CrInst_FIRE_ARROW,        156, LONG_MAX},
-    {CrInst_WORD_OF_POWER,       0, 284},
-    {CrInst_FART,                0, 284},
-    {CrInst_FLAME_BREATH,      156, 284},
-    {CrInst_SWING_WEAPON_SWORD,  0, 284},
-    {CrInst_SWING_WEAPON_FIST,   0, 284},
-    {CrInst_NULL,                0,   0},
+    {CrInst_FREEZE,                 156, LONG_MAX},
+    {CrInst_FEAR,                   156, LONG_MAX},
+    {CrInst_CAST_SPELL_DISEASE,     156, LONG_MAX},
+    {CrInst_CAST_SPELL_CHICKEN,     156, LONG_MAX},
+    {CrInst_CAST_SPELL_TIME_BOMB,   768, LONG_MAX},
+    {CrInst_FIRE_BOMB,              768, LONG_MAX},
+    {CrInst_LIGHTNING,              768, LONG_MAX},
+    {CrInst_HAILSTORM,              156, LONG_MAX},
+    {CrInst_POISON_CLOUD,           156, LONG_MAX},
+    {CrInst_DRAIN,                  156, LONG_MAX},
+    {CrInst_SLOW,                   156, LONG_MAX},
+    {CrInst_NAVIGATING_MISSILE,     156, LONG_MAX},
+    {CrInst_MISSILE,                156, LONG_MAX},
+    {CrInst_FIREBALL,               156, LONG_MAX},
+    {CrInst_FIRE_ARROW,             156, LONG_MAX},
+    {CrInst_WORD_OF_POWER,            0, 284},
+    {CrInst_FART,                     0, 284},
+    {CrInst_FLAME_BREATH,           156, 284},
+    {CrInst_SWING_WEAPON_SWORD,       0, 284},
+    {CrInst_SWING_WEAPON_FIST,        0, 284},
+    {CrInst_NULL,                     0,   0},
 };
 
 const struct CombatWeapon melee_offensive_weapon[] = {
     {CrInst_HAILSTORM,         156, LONG_MAX},
     {CrInst_FREEZE,            156, LONG_MAX},
-	{CrInst_FEAR,              156, LONG_MAX},
-	{CrInst_CAST_SPELL_DISEASE,	 156, LONG_MAX},
-	{CrInst_CAST_SPELL_CHICKEN,	 156, LONG_MAX},
+    {CrInst_FEAR,              156, LONG_MAX},
+    {CrInst_CAST_SPELL_DISEASE,156, LONG_MAX},
+    {CrInst_CAST_SPELL_CHICKEN,156, LONG_MAX},
     {CrInst_SLOW,              156, LONG_MAX},
     {CrInst_WORD_OF_POWER,       0, 284},
     {CrInst_FART,                0, 284},
@@ -326,8 +326,8 @@ TbBool creature_is_actually_scared(const struct Thing *creatng, const struct Thi
     // fear_wounded percent of base health
     HitPoints crmaxhealth,enmaxhealth;
     long fear;
-    //TODO: Remove feer_noflee_factor as allowing creatures to retreat on low health should not cause them to be more fearfull.
-	if (player_creature_tends_to(creatng->owner,CrTend_Flee) || (crstat->fear_noflee_factor <= 0)) {
+    //TODO: Remove fear_noflee_factor as allowing creatures to retreat on low health should not cause them to be more fearfull.
+    if (player_creature_tends_to(creatng->owner,CrTend_Flee) || (crstat->fear_noflee_factor <= 0)) {
         // In flee mode, use full fear value
         fear = crstat->fear_wounded * 10;
     } else {
@@ -342,6 +342,7 @@ TbBool creature_is_actually_scared(const struct Thing *creatng, const struct Thi
     if (creatng->health < (fear * (long long)crmaxhealth) / 1000)
     {
         SYNCDBG(8,"The %s index %d is scared due to low health (%ld/%ld)",thing_model_name(creatng),(int)creatng->index,(long)creatng->health,crmaxhealth);
+        //reset_creature_if_affected_by_cta(creatng);
         return true;
     }
     // If the enemy is way stronger, a creature may be scared anyway
@@ -356,7 +357,7 @@ TbBool creature_is_actually_scared(const struct Thing *creatng, const struct Thi
     if (enmstrength >= (fear * ownstrength) / 100)
     {
         // TODO: Base fear on score, not strenght as that causes issues with fearfull spellcasters.
-		// check if there are allied creatures nearby; assume that such creatures are multiplying strength of the creature we're checking
+        // check if there are allied creatures nearby; assume that such creatures are multiplying strength of the creature we're checking
         long support_count;
         support_count = count_creatures_near_and_owned_by_or_allied_with(creatng->mappos.x.val, creatng->mappos.y.val, 9, creatng->owner);
         ownstrength *= support_count;

--- a/src/magic.c
+++ b/src/magic.c
@@ -879,7 +879,7 @@ TbResult magic_use_power_armageddon(PlayerNumber plyr_idx, unsigned long mod_fla
 }
 
 /**
- * Starts and stops the use of Must bey.
+ * Starts and stops the use of Must obey.
  * What differs this power from others is that it is a toggle - pressing once
  * starts the power, and second press disables it.
  * The spell is paid for somewhere else - it takes money every few turns when active.
@@ -1493,7 +1493,7 @@ TbBool update_creature_influenced_by_call_to_arms_at_pos(struct Thing *creatng, 
 {
     struct CreatureControl *cctrl;
     cctrl = creature_control_get_from_thing(creatng);
-    if (!creature_can_navigate_to_with_storage(creatng, cta_pos, NavRtF_Default))
+    if (!creature_can_navigate_to_with_storage(creatng, cta_pos, NavRtF_Default) || process_creature_needs_to_heal_critical(creatng))
     {
         creature_stop_affected_by_call_to_arms(creatng);
         return false;
@@ -1544,7 +1544,7 @@ long update_creatures_influenced_by_call_to_arms(PlayerNumber plyr_idx)
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        if (!thing_is_picked_up(thing) && !creature_is_being_unconscious(thing))// && !creature_is_fleeing_combat(thing))
+        if (!thing_is_picked_up(thing) && !creature_is_being_unconscious(thing))
         {
             if (creature_affected_by_call_to_arms(thing))
             {

--- a/src/magic.c
+++ b/src/magic.c
@@ -1544,7 +1544,7 @@ long update_creatures_influenced_by_call_to_arms(PlayerNumber plyr_idx)
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        if (!thing_is_picked_up(thing) && !creature_is_being_unconscious(thing))
+        if (!thing_is_picked_up(thing) && !creature_is_being_unconscious(thing))// && !creature_is_fleeing_combat(thing))
         {
             if (creature_affected_by_call_to_arms(thing))
             {


### PR DESCRIPTION
This fixes a bug where units would return to the lair/hatchery when low on health, but not actually tend to their needs and die.

Units will now break free of CTA when at critical health.