### PR TITLE
Added ON_ENEMY_GROUND, ON_FRIENDLY_GROUND and ANYWHERE as criteria for KILL_CREATURE script command

### DIFF
--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -371,7 +371,8 @@ const struct NamedCommand creature_select_criteria_desc[] = {
   {"NEAR_OWN_HEART",       CSelCrit_NearOwnHeart},
   {"NEAR_ENEMY_HEART",     CSelCrit_NearEnemyHeart},
   {"ON_ENEMY_GROUND",      CSelCrit_OnEnemyGround},
-  {"ANY",                  CSelCrit_Any},
+  {"ON_FRIENDLY_GROUND",   CSelCrit_OnFriendlyGround},
+  {"ANYWHERE",             CSelCrit_Any},
   {NULL,                   0},
 };
 
@@ -3637,7 +3638,6 @@ long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingMode
     count = 0;
     i = thing_idx;
     k = 0;
-    JUSTMSG("TESTLOG: Count on territory. Friendly = %d",friendly);
     while (i != 0)
     {
         struct CreatureControl *cctrl;
@@ -3655,7 +3655,6 @@ long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingMode
         if ( (thing->model == crmodel) && ( (players_are_enemies(thing->owner,slbwnr) && (friendly == 0)) || (players_are_mutual_allies(thing->owner,slbwnr) && (friendly == 1)) ) )
         {
             count++;
-            JUSTMSG("TESTLOG: Counted %d units of model %d from owner %d",count, crmodel,thing->owner);
         }
         // Per creature code ends
         k++;
@@ -3717,6 +3716,9 @@ TbBool script_kill_creature_with_criteria(PlayerNumber plyr_idx, long crmodel, l
         break;
     case CSelCrit_OnEnemyGround:
         thing = get_random_players_creature_of_model_on_territory(plyr_idx, crmodel,0);
+        break;
+    case CSelCrit_OnFriendlyGround:
+        thing = get_random_players_creature_of_model_on_territory(plyr_idx, crmodel,1);
         break;
     default:
         ERRORLOG("Invalid kill criteria %d",(int)criteria);

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -3629,14 +3629,15 @@ struct Thing *get_creature_in_range_around_any_of_enemy_heart(PlayerNumber plyr_
     return INVALID_THING;
 }
 
-long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingModel crmodel)
+long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingModel crmodel, int friendly)
 {
     unsigned long k;
     long i;
-    int count,slbwnr,rvlr;
+    int count,slbwnr;
     count = 0;
     i = thing_idx;
     k = 0;
+    JUSTMSG("TESTLOG: Count on territory. Friendly = %d",friendly);
     while (i != 0)
     {
         struct CreatureControl *cctrl;
@@ -3651,10 +3652,11 @@ long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingMode
         i = cctrl->players_next_creature_idx;
         // Per creature code
         slbwnr = get_slab_owner_thing_is_on(thing);
-        rvlr = players_are_enemies(thing->owner,slbwnr);
-        JUSTMSG("TESTLOG: Unit is on rival ground = %d",rvlr);
-        if ((thing->model == crmodel) && (rvlr == 1))
+        if ( (thing->model == crmodel) && ( (players_are_enemies(thing->owner,slbwnr) && (friendly == 0)) || (players_are_mutual_allies(thing->owner,slbwnr) && (friendly == 1)) ) )
+        {
             count++;
+            JUSTMSG("TESTLOG: Counted %d units of model %d from owner %d",count, crmodel,thing->owner);
+        }
         // Per creature code ends
         k++;
         if (k > THINGS_COUNT)
@@ -3663,7 +3665,6 @@ long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingMode
             break;
         }
     }
-    //JUSTMSG("TESTLOG: Counted %d units model %d from owner %d",count, crmodel,thing->owner);
     return count;
 }
 
@@ -3715,7 +3716,7 @@ TbBool script_kill_creature_with_criteria(PlayerNumber plyr_idx, long crmodel, l
         thing = get_creature_in_range_around_any_of_enemy_heart(plyr_idx, crmodel, 11);
         break;
     case CSelCrit_OnEnemyGround:
-        thing = get_random_players_creature_of_model_on_territory(plyr_idx, crmodel);
+        thing = get_random_players_creature_of_model_on_territory(plyr_idx, crmodel,0);
         break;
     default:
         ERRORLOG("Invalid kill criteria %d",(int)criteria);

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2029,7 +2029,7 @@ long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel)
 {
     unsigned long k;
     long i;
-    int count;
+    int count,owner;
     count = 0;
     i = thing_idx;
     k = 0;
@@ -2038,6 +2038,7 @@ long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel)
         struct CreatureControl *cctrl;
         struct Thing *thing;
         thing = thing_get(i);
+        cctrl = creature_control_get_from_thing(thing);
         if (thing_is_invalid(thing))
         {
           ERRORLOG("Jump to invalid thing detected");
@@ -2047,7 +2048,11 @@ long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel)
         i = cctrl->players_next_creature_idx;
         // Per creature code
         if ((crmodel <= 0) || (thing->model == crmodel))
+        {
+            owner = get_slab_owner_thing_is_on(thing);
+            JUSTMSG("TESTLOG: Thing owner is %d, Slab owner is %d",thing->owner,owner);
             count++;
+        }
         // Per creature code ends
         k++;
         if (k > THINGS_COUNT)
@@ -2089,6 +2094,43 @@ struct Thing *get_player_list_nth_creature_of_model(long thing_idx, ThingModel c
       if ((crtr_idx <= 0) || (thing->model == crmodel && crtr_idx <= 1))
           return thing;
       if ((crmodel <= 0) || (thing->model == crmodel))
+          crtr_idx--;
+      // Per creature code ends
+      k++;
+      if (k > THINGS_COUNT)
+      {
+        ERRORLOG("Infinite loop detected when sweeping things list");
+        return INVALID_THING;
+      }
+    }
+    ERRORLOG("Tried to get creature of index exceeding list");
+    return INVALID_THING;
+}
+struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx, ThingModel crmodel, long crtr_idx)
+{
+    struct CreatureControl *cctrl;
+    struct Thing *thing;
+    unsigned long k;
+    long i;
+    int slbwnr,rvlr;
+    i = thing_idx;
+    k = 0;
+    while (i != 0)
+    {
+      thing = thing_get(i);
+      if (thing_is_invalid(thing))
+      {
+        ERRORLOG("Jump to invalid thing detected");
+        return INVALID_THING;
+      }
+      cctrl = creature_control_get_from_thing(thing);
+      i = cctrl->players_next_creature_idx;
+      // Per creature code
+      slbwnr = get_slab_owner_thing_is_on(thing);
+      rvlr = players_are_enemies(thing->owner,slbwnr);
+      if (((crtr_idx <= 0) || (thing->model == crmodel && crtr_idx <= 1)) && (rvlr == 1))
+          return thing;
+      if ((crmodel <= 0) || ((thing->model == crmodel) && (rvlr == 1)))
           crtr_idx--;
       // Per creature code ends
       k++;
@@ -2166,6 +2208,18 @@ struct Thing *get_random_players_creature_of_model(PlayerNumber plyr_idx, ThingM
         return INVALID_THING;
     crtr_idx = ACTION_RANDOM(total_count)+1;
     return get_player_list_nth_creature_of_model(dungeon->creatr_list_start, crmodel, crtr_idx);
+}
+
+struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber plyr_idx, ThingModel crmodel)
+{
+    struct Dungeon *dungeon;
+    long total_count,crtr_idx;
+    dungeon = get_players_num_dungeon(plyr_idx);
+    total_count = count_player_list_creatures_of_model_on_territory(dungeon->creatr_list_start, crmodel);
+    if (total_count < 1)
+        return INVALID_THING;
+    crtr_idx = ACTION_RANDOM(total_count)+1;
+    return get_player_list_nth_creature_of_model_on_territory(dungeon->creatr_list_start, crmodel, crtr_idx);
 }
 
 /**

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2029,7 +2029,7 @@ long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel)
 {
     unsigned long k;
     long i;
-    int count,owner;
+    int count;
     count = 0;
     i = thing_idx;
     k = 0;
@@ -2044,12 +2044,10 @@ long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel)
           ERRORLOG("Jump to invalid thing detected");
           break;
         }
-        cctrl = creature_control_get_from_thing(thing);
         i = cctrl->players_next_creature_idx;
         // Per creature code
         if ((crmodel <= 0) || (thing->model == crmodel))
         {
-            owner = get_slab_owner_thing_is_on(thing);
             count++;
         }
         // Per creature code ends
@@ -2233,7 +2231,9 @@ struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber ply
     dungeon = get_players_num_dungeon(plyr_idx);
     total_count = count_player_list_creatures_of_model_on_territory(dungeon->creatr_list_start, crmodel, friendly);
     if (total_count < 1)
-        return INVALID_THING;
+    {
+      return INVALID_THING;
+    }
     crtr_idx = ACTION_RANDOM(total_count)+1;
     return get_player_list_nth_creature_of_model_on_territory(dungeon->creatr_list_start, crmodel, crtr_idx, friendly);
 }

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2050,7 +2050,6 @@ long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel)
         if ((crmodel <= 0) || (thing->model == crmodel))
         {
             owner = get_slab_owner_thing_is_on(thing);
-            JUSTMSG("TESTLOG: Thing owner is %d, Slab owner is %d",thing->owner,owner);
             count++;
         }
         // Per creature code ends
@@ -2115,7 +2114,6 @@ struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx,
     int slbwnr,match;
     i = thing_idx;
     k = 0;
-    JUSTMSG("TESTLOG: We want number %d on the list. Friendly is %d",crtr_idx,friendly);
     while (i != 0)
     {
       thing = thing_get(i);
@@ -2134,24 +2132,20 @@ struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx,
         if (players_are_mutual_allies(thing->owner,slbwnr));
         {
           match = 1;
-          JUSTMSG("TESTLOG: To business, matched because we're allies.");
         }
       } else
       {
         if (players_are_enemies(thing->owner,slbwnr));
         {
           match = 1;
-          JUSTMSG("TESTLOG: to business, matched because we're enemies.");
         }
       }
       if (((crtr_idx <= 0) || (thing->model == crmodel && crtr_idx <= 1)) && (match == 1))
       {
-          JUSTMSG("TESTLOG: Counter at %d. We found it!.",crtr_idx);
           return thing;
       }
       if ((crmodel <= 0) || ((thing->model == crmodel) && (match == 1)))
       {
-          JUSTMSG("TESTLOG: We found a match. Counter at %d.",crtr_idx);
           crtr_idx--;
       }
       // Per creature code ends
@@ -2238,7 +2232,6 @@ struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber ply
     long total_count,crtr_idx;
     dungeon = get_players_num_dungeon(plyr_idx);
     total_count = count_player_list_creatures_of_model_on_territory(dungeon->creatr_list_start, crmodel, friendly);
-    JUSTMSG("TESTLOG: Got a total count of %d units. Friendly = %d",total_count,friendly);
     if (total_count < 1)
         return INVALID_THING;
     crtr_idx = ACTION_RANDOM(total_count)+1;

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -198,9 +198,9 @@ long count_player_list_creatures_with_filter(long thing_idx, Thing_Maximizer_Fil
 long count_player_list_creatures_of_model_matching_bool_filter(PlayerNumber plyr_idx, int tngmodel, Thing_Bool_Filter matcher_cb);
 // Final routines to select creature anywhere on map but belonging to given player
 struct Thing *get_player_list_nth_creature_of_model(long thing_idx, ThingModel crmodel, long crtr_idx);
-struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx, ThingModel crmodel, long crtr_idx);
+struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx, ThingModel crmodel, long crtr_idx, int friendly);
 struct Thing *get_random_players_creature_of_model(PlayerNumber plyr_idx, ThingModel crmodel);
-struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber plyr_idx, ThingModel crmodel);
+struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber plyr_idx, ThingModel crmodel,int friendly);
 struct Thing *find_players_highest_level_creature_of_breed_and_gui_job(long crmodel, long job_idx, PlayerNumber plyr_idx, unsigned char pick_check);
 struct Thing *find_players_lowest_level_creature_of_breed_and_gui_job(long crmodel, long job_idx, PlayerNumber plyr_idx, unsigned char pick_check);
 long do_to_players_all_creatures_of_model(PlayerNumber plyr_idx, int crmodel, Thing_Bool_Modifier do_cb);
@@ -279,7 +279,7 @@ TbBool perform_action_on_all_creatures_in_group(struct Thing *thing, Thing_Bool_
 long creature_of_model_in_prison_or_tortured(ThingModel crmodel);
 long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel);
 long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel);
-long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingModel crmodel);
+long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingModel crmodel, int friendly);
 GoldAmount compute_player_payday_total(const struct Dungeon *dungeon);
 TbBool lord_of_the_land_in_prison_or_tortured(void);
 struct Thing *lord_of_the_land_find(void);

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -198,7 +198,9 @@ long count_player_list_creatures_with_filter(long thing_idx, Thing_Maximizer_Fil
 long count_player_list_creatures_of_model_matching_bool_filter(PlayerNumber plyr_idx, int tngmodel, Thing_Bool_Filter matcher_cb);
 // Final routines to select creature anywhere on map but belonging to given player
 struct Thing *get_player_list_nth_creature_of_model(long thing_idx, ThingModel crmodel, long crtr_idx);
+struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx, ThingModel crmodel, long crtr_idx);
 struct Thing *get_random_players_creature_of_model(PlayerNumber plyr_idx, ThingModel crmodel);
+struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber plyr_idx, ThingModel crmodel);
 struct Thing *find_players_highest_level_creature_of_breed_and_gui_job(long crmodel, long job_idx, PlayerNumber plyr_idx, unsigned char pick_check);
 struct Thing *find_players_lowest_level_creature_of_breed_and_gui_job(long crmodel, long job_idx, PlayerNumber plyr_idx, unsigned char pick_check);
 long do_to_players_all_creatures_of_model(PlayerNumber plyr_idx, int crmodel, Thing_Bool_Modifier do_cb);
@@ -277,6 +279,7 @@ TbBool perform_action_on_all_creatures_in_group(struct Thing *thing, Thing_Bool_
 long creature_of_model_in_prison_or_tortured(ThingModel crmodel);
 long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel);
 long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel);
+long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingModel crmodel);
 GoldAmount compute_player_payday_total(const struct Dungeon *dungeon);
 TbBool lord_of_the_land_in_prison_or_tortured(void);
 struct Thing *lord_of_the_land_find(void);

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -84,6 +84,7 @@ enum CreatureSelectCriteria {
     CSelCrit_NearOwnHeart      =  9,
     CSelCrit_NearEnemyHeart    = 10,
     CSelCrit_OnEnemyGround     = 11,
+    CSelCrit_OnFriendlyGround  = 12,
 };
 
 //TODO replace HitType with these


### PR DESCRIPTION
ANYWHERE is simply ANY from the previous commit renamed
ON_ENEMY_GROUND was already accepted, but did not have any actual functionality
ON_FRIENDLY_GROUND is completely new

Allows units to be killed on friendly ground, enemy ground, or just anywhere. Also, criteria are possible to use on future script commands.