### PR TITLE
Clicking on a creature portrait (w/o ctrl) picks up the strongest first

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1452,10 +1452,11 @@ void pick_up_next_creature(struct GuiButton *gbtn)
     }
 
     pick_flags = TPF_PickableCheck;
-    if (lbKeyOn[KC_LCONTROL] || lbKeyOn[KC_RCONTROL])
-        pick_flags |= TPF_OrderedPick;
-    if (lbKeyOn[KC_LSHIFT] || lbKeyOn[KC_RSHIFT])
-        pick_flags |= TPF_ReverseOrder;
+	pick_flags |= TPF_OrderedPick;
+	if (lbKeyOn[KC_LSHIFT] || lbKeyOn[KC_RSHIFT])
+	{
+		pick_flags |= TPF_ReverseOrder;
+	}
     pick_up_creature_of_model_and_gui_job(kind, CrGUIJob_Any, my_player_number, pick_flags);
 }
 


### PR DESCRIPTION
If we want the original functionality where clicking on a creature icon (without pressing Ctrl) will pickup the strongest first, this achieves it. But maybe that's no longer wanted and current behavior with Ctrl+click for picking up strongest is more desirable. If the latter, discard this PR. Fixes the closed issue #1 

Additionally, we could use Ctrl in a reverse manner (not implemented yet), to pick up creatures in no particular order if that's still a useful action. Thoughts?