### PR TITLE
Possess chicken no error on exit

### DIFF
--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1057,6 +1057,7 @@ TbBool is_thing_directly_controlled(const struct Thing *thing)
     player = get_player(thing->owner);
     if ((player->work_state != PSt_CtrlDirect) && (player->work_state != PSt_FreeCtrlDirect))
         return false;
+	char playerInstanceNum = player->instance_num;
     switch (player->instance_num)
     {
     case PI_DirctCtrl:
@@ -1069,6 +1070,8 @@ TbBool is_thing_directly_controlled(const struct Thing *thing)
     case PI_Whip: // Whip can be used at any time by comp. assistant
     case PI_WhipEnd:
         return (thing->index == player->controlled_thing_idx);
+	case PI_PsngrCtLeave: // Leaving the possessed creature
+		break;
     default:
         ERRORLOG("Bad player %d instance %d",(int)thing->owner,(int)player->instance_num);
         break;


### PR DESCRIPTION
It simply wasn't handling the case when the user was leaving the possessed creature and was unnecessarily freaking out. Fixes #73

The char playerInstanceNum was added just because it allows you see the value while debugging, and could be useful for future debugging sessions when needed, since player->instance_num cannot be accessed while debugging.