### PR TITLE
Rewritten _DK_setup_head_for_empty_treasure_space

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2977,8 +2977,10 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     MapSlabCoord slb_y = slb_num_decode_y(slbnum);
     struct Thing* gldtng = find_gold_hoarde_at(slab_subtile_center(slb_x), slab_subtile_center(slb_y));
 
-    // If the random slab is empty, don't bother continuing and just go there
-    if (gldtng->valuable.gold_stored <= 0)
+    // If the random slab has enough space to drop all gold, go there to drop it
+    long wealth_size_holds = gold_per_hoard / get_wealth_size_types_count();
+    GoldAmount max_hoard_size_in_room = wealth_size_holds * room->total_capacity / room->slabs_count;
+    if((max_hoard_size_in_room - gldtng->valuable.gold_stored) >= thing->creature.gold_carried)
     {
         slb_x = slb_num_decode_x(slbnum);
         slb_y = slb_num_decode_y(slbnum);
@@ -2988,7 +2990,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
         }
     }
 
-    //Find a slab with the lowest amount of gold
+    //If not, find a slab with the lowest amount of gold
     GoldAmount gold_amount = gldtng->valuable.gold_stored;
     GoldAmount gold_low_amount = gldtng->valuable.gold_stored;
     SlabCodedCoords slblow = start_slbnum;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2955,13 +2955,11 @@ short creature_wants_salary(struct Thing *creatng)
 
 long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
 {
-    //return _DK_setup_head_for_empty_treasure_space(thing, room);
-    unsigned long k;
+    // _DK_setup_head_for_empty_treasure_space(thing, room);
     SlabCodedCoords start_slbnum = room->slabs_list;
-    //long wealth_size_holds = gold_per_hoard / get_wealth_size_types_count();
-    //GoldAmount max_hoard_size_in_room = wealth_size_holds * room->total_capacity / room->slabs_count;
-    
-    //Random start slab
+   
+    //Find a random slab to start out with
+    unsigned long k;
     long n = ACTION_RANDOM(room->slabs_count);
     for (k = n; k > 0; k--)
     {
@@ -2979,7 +2977,8 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     MapSlabCoord slb_y = slb_num_decode_y(slbnum);
     struct Thing* gldtng = find_gold_hoarde_at(slab_subtile_center(slb_x), slab_subtile_center(slb_y));
 
-    if (gldtng->valuable.gold_stored <= 0) // If we find an empty slab, don't bother continuing
+    // If the random slab is empty, don't bother continuing and just go there
+    if (gldtng->valuable.gold_stored <= 0)
     {
         slb_x = slb_num_decode_x(slbnum);
         slb_y = slb_num_decode_y(slbnum);
@@ -2991,7 +2990,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
         }
     }
 
-    //Find a slab with the lowest amount
+    //Find a slab with the lowest amount of gold
     GoldAmount gold_amount = gldtng->valuable.gold_stored;
     GoldAmount gold_low_amount = gldtng->valuable.gold_stored;
     SlabCodedCoords slblow = start_slbnum;
@@ -3001,7 +3000,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
         slb_y = slb_num_decode_y(slbnum);
         gldtng = find_gold_hoarde_at(slab_subtile_center(slb_x), slab_subtile_center(slb_y));
         gold_amount = gldtng->valuable.gold_stored;
-        if (gold_amount <= 0)
+        if (gold_amount <= 0) //Any empty slab will do
         {
             slblow = slbnum;
             break;
@@ -3019,13 +3018,11 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
         
     }
     
-    //TODO: ERROR if slablow holds max value or more
-
+    //Send imp to slab with lowest amount on it
     slb_x = slb_num_decode_x(slblow);
     slb_y = slb_num_decode_y(slblow);
     long stl_x = slab_subtile_center(slb_x);
     long stl_y = slab_subtile_center(slb_y);
-    //Send imp to slab with lowest amount on it
     if (setup_person_move_to_position(thing, stl_x, stl_y, NavRtF_Default))
     {
         return 1;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2955,7 +2955,7 @@ short creature_wants_salary(struct Thing *creatng)
 
 long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
 {
-    // _DK_setup_head_for_empty_treasure_space(thing, room);
+    // return _DK_setup_head_for_empty_treasure_space(thing, room);
     SlabCodedCoords start_slbnum = room->slabs_list;
    
     //Find a random slab to start out with
@@ -2982,9 +2982,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     {
         slb_x = slb_num_decode_x(slbnum);
         slb_y = slb_num_decode_y(slbnum);
-        long stl_x = slab_subtile_center(slb_x);
-        long stl_y = slab_subtile_center(slb_y);
-        if (setup_person_move_to_position(thing, stl_x, stl_y, NavRtF_Default))
+        if (setup_person_move_to_position(thing, slab_subtile_center(slb_x), slab_subtile_center(slb_y), NavRtF_Default))
         {
             return 1;
         }
@@ -3021,9 +3019,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     //Send imp to slab with lowest amount on it
     slb_x = slb_num_decode_x(slblow);
     slb_y = slb_num_decode_y(slblow);
-    long stl_x = slab_subtile_center(slb_x);
-    long stl_y = slab_subtile_center(slb_y);
-    if (setup_person_move_to_position(thing, stl_x, stl_y, NavRtF_Default))
+    if (setup_person_move_to_position(thing, slab_subtile_center(slb_x), slab_subtile_center(slb_y), NavRtF_Default))
     {
         return 1;
     }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2957,16 +2957,17 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     SlabCodedCoords start_slbnum = room->slabs_list;
    
     //Find a random slab to start out with
-    unsigned long k;
     long n = ACTION_RANDOM(room->slabs_count);
-    for (k = n; k > 0; k--)
+    for (unsigned long k = n; k > 0; k--)
     {
         if (start_slbnum == 0)
+        {
             break;
+        }
         start_slbnum = get_next_slab_number_in_room(start_slbnum);
     }
     if (start_slbnum == 0) {
-        ERRORLOG("Taking random slab (%d/%d) in %s index %d failed - internal inconsistency.", (int)n, (int)room->slabs_count, room_code_name(room->kind), (int)room->index);
+        ERRORLOG("Taking random slab (%d/%u) in %s index %u failed - internal inconsistency.", n, room->slabs_count, room_code_name(room->kind), room->index);
         start_slbnum = room->slabs_list;
     }
     

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2958,8 +2958,8 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     //return _DK_setup_head_for_empty_treasure_space(thing, room);
     unsigned long k;
     SlabCodedCoords start_slbnum = room->slabs_list;
-    long wealth_size_holds = gold_per_hoard / get_wealth_size_types_count();
-    GoldAmount max_hoard_size_in_room = wealth_size_holds * room->total_capacity / room->slabs_count;
+    //long wealth_size_holds = gold_per_hoard / get_wealth_size_types_count();
+    //GoldAmount max_hoard_size_in_room = wealth_size_holds * room->total_capacity / room->slabs_count;
     
     //Random start slab
     long n = ACTION_RANDOM(room->slabs_count);
@@ -3012,6 +3012,11 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
             slblow = slbnum;
         }
         slbnum = get_next_slab_number_in_room(slbnum);
+        if (slbnum == 0) 
+        {
+            slbnum = room->slabs_list;
+        }
+        
     }
     
     //TODO: ERROR if slablow holds max value or more

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2990,7 +2990,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     //If not, find a slab with the lowest amount of gold
     GoldAmount gold_amount = gldtng->valuable.gold_stored;
     GoldAmount min_gold_amount = gldtng->valuable.gold_stored;
-    SlabCodedCoords slblow = start_slbnum;
+    SlabCodedCoords slbmin = start_slbnum;
     for (long i = room->slabs_count; i > 0; i--)
     { 
         slb_x = slb_num_decode_x(slbnum);
@@ -2999,13 +2999,13 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
         gold_amount = gldtng->valuable.gold_stored;
         if (gold_amount <= 0) //Any empty slab will do
         {
-            slblow = slbnum;
+            slbmin = slbnum;
             break;
         }
         if (gold_amount <= min_gold_amount)
         { 
             min_gold_amount = gold_amount;
-            slblow = slbnum;
+            slbmin = slbnum;
         }
         slbnum = get_next_slab_number_in_room(slbnum);
         if (slbnum == 0) 
@@ -3016,8 +3016,8 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     }
     
     //Send imp to slab with lowest amount on it
-    slb_x = slb_num_decode_x(slblow);
-    slb_y = slb_num_decode_y(slblow);
+    slb_x = slb_num_decode_x(slbmin);
+    slb_y = slb_num_decode_y(slbmin);
     if (setup_person_move_to_position(thing, slab_subtile_center(slb_x), slab_subtile_center(slb_y), NavRtF_Default))
     {
         return 1;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -92,7 +92,6 @@ DLLIMPORT long _DK_move_check_can_damage_wall(struct Thing *creatng);
 DLLIMPORT long _DK_move_check_on_head_for_room(struct Thing *creatng);
 DLLIMPORT long _DK_move_check_persuade(struct Thing *creatng);
 DLLIMPORT long _DK_move_check_wait_at_door_for_wage(struct Thing *creatng);
-DLLIMPORT long _DK_setup_head_for_empty_treasure_space(struct Thing *creatng, struct Room *room);
 DLLIMPORT long _DK_get_best_position_outside_room(struct Thing *creatng, struct Coord3d *pos, struct Room *room);
 /******************************************************************************/
 short already_at_call_to_arms(struct Thing *creatng);
@@ -2955,7 +2954,6 @@ short creature_wants_salary(struct Thing *creatng)
 
 long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
 {
-    // return _DK_setup_head_for_empty_treasure_space(thing, room);
     SlabCodedCoords start_slbnum = room->slabs_list;
    
     //Find a random slab to start out with
@@ -2982,8 +2980,6 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
     GoldAmount max_hoard_size_in_room = wealth_size_holds * room->total_capacity / room->slabs_count;
     if((max_hoard_size_in_room - gldtng->valuable.gold_stored) >= thing->creature.gold_carried)
     {
-        slb_x = slb_num_decode_x(slbnum);
-        slb_y = slb_num_decode_y(slbnum);
         if (setup_person_move_to_position(thing, slab_subtile_center(slb_x), slab_subtile_center(slb_y), NavRtF_Default))
         {
             return 1;
@@ -2992,7 +2988,7 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
 
     //If not, find a slab with the lowest amount of gold
     GoldAmount gold_amount = gldtng->valuable.gold_stored;
-    GoldAmount gold_low_amount = gldtng->valuable.gold_stored;
+    GoldAmount min_gold_amount = gldtng->valuable.gold_stored;
     SlabCodedCoords slblow = start_slbnum;
     for (long i = room->slabs_count; i > 0; i--)
     { 
@@ -3005,9 +3001,9 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
             slblow = slbnum;
             break;
         }
-        if (gold_amount <= gold_low_amount)
+        if (gold_amount <= min_gold_amount)
         { 
-            gold_low_amount = gold_amount;
+            min_gold_amount = gold_amount;
             slblow = slbnum;
         }
         slbnum = get_next_slab_number_in_room(slbnum);

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -196,6 +196,7 @@ TbBool thing_is_on_any_room_tile(const struct Thing *thing);
 TbBool thing_is_on_own_room_tile(const struct Thing *thing);
 struct Room *get_room_thing_is_on(const struct Thing *thing);
 void reinitialise_map_rooms(void);
+struct Thing *find_gold_hoarde_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 // Finding position within room
 TbBool find_random_valid_position_for_thing_in_room(struct Thing *thing, struct Room *room, struct Coord3d *pos);
@@ -214,7 +215,6 @@ struct Room *find_room_nearest_to_position(PlayerNumber plyr_idx, RoomKind rkind
 struct Room *find_room_for_thing_with_used_capacity(const struct Thing *creatng, PlayerNumber plyr_idx, RoomKind rkind, unsigned char nav_flags, long min_used_cap);
 struct Room *find_random_room_with_used_capacity_creature_can_navigate_to(struct Thing *thing, PlayerNumber owner, RoomKind rkind, unsigned char nav_flags);
 struct Room *find_nearest_room_for_thing_with_spare_capacity(struct Thing *thing, signed char owner, RoomKind rkind, unsigned char nav_flags, long spare);
-extern struct Thing* find_gold_hoarde_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 void create_room_flag(struct Room *room);
 void delete_room_flag(struct Room *room);

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -214,6 +214,7 @@ struct Room *find_room_nearest_to_position(PlayerNumber plyr_idx, RoomKind rkind
 struct Room *find_room_for_thing_with_used_capacity(const struct Thing *creatng, PlayerNumber plyr_idx, RoomKind rkind, unsigned char nav_flags, long min_used_cap);
 struct Room *find_random_room_with_used_capacity_creature_can_navigate_to(struct Thing *thing, PlayerNumber owner, RoomKind rkind, unsigned char nav_flags);
 struct Room *find_nearest_room_for_thing_with_spare_capacity(struct Thing *thing, signed char owner, RoomKind rkind, unsigned char nav_flags, long spare);
+extern struct Thing* find_gold_hoarde_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 void create_room_flag(struct Room *room);
 void delete_room_flag(struct Room *room);


### PR DESCRIPTION
Changed the algorithm to no longer take a random tile with empty space, but goes to a random tile with the least amount of gold on it.

Fixes an issue where imps would keep looking for free space because of the increased number of hoards in keeperfx.