### PR TITLE
Fix WoP sound not playing when used only as an effect.

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -1,5 +1,5 @@
 ; KeeperFX Magic Configuration file
-; file version 0.44
+; file version 0.45
 
 [common]
 ; Spells are casted by creatures at their position. They can affect the caster or surrounding

--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -742,7 +742,7 @@ HitType = 4
 AreaDamage = 5 150 128
 SpellEffect = 0
 Speed = 0
-FiringSound = 178
+FiringSound = 0
 ShotSound = 0
 Properties = REBOUND_IMMUNE NO_HIT
 
@@ -757,7 +757,7 @@ HitType = 2
 AreaDamage = 8 150 512
 SpellEffect = 0
 Speed = 0
-FiringSound = 178
+FiringSound = 0
 ShotSound = 0
 Properties = REBOUND_IMMUNE NO_HIT
 

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -1219,7 +1219,7 @@ struct Thing *create_effect(const struct Coord3d *pos, ThingModel effmodel, Play
     }
     add_thing_to_its_class_list(thing);
     place_thing_in_mapwho(thing);
-    if ((ieffect->effect_sound != 0) && (ieffect->area_affect_type != AAffT_WOPDamage)) //Excluding WOP effect, taking shot sound instead
+    if (ieffect->effect_sound != 0)
     {
         thing_play_sample(thing, ieffect->effect_sound, NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
     }


### PR DESCRIPTION
WoP now by default gets its sound effect from effects.cfg.