### PR TITLE
Fix host being taken over by the AI when somene leaves a multiplayer …

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -2499,7 +2499,7 @@ void process_packets(void)
             for (i = 0; i < 4; i++)
             {
                 player = get_player(i);
-                if (network_player_active(player->packet_num))
+                if (!network_player_active(player->packet_num))
                 {
                     player->allocflags |= PlaF_CompCtrl;
                     toggle_computer_player(i);


### PR DESCRIPTION
…game

The player who left should be taken over instead.