### PR TITLE
Update engine_camera.c - remove unnecessary lines

### DIFF
--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -299,12 +299,6 @@ unsigned long scale_camera_zoom_to_screen(unsigned long zoom_lvl)
 {
     unsigned long size_narr = ((pixel_size * units_per_pixel_min) << 7) / 10;
     unsigned long size_wide = (pixel_size * units_per_pixel) << 3;
-    // Currently, the side menu isn't scaled. We have to take that into account. Side menu takes approx 0.22 of the screen.
-    // Note that this is temporary - it would be better to scale the side menu. Not to mention making larger rendering arrays.
-    if (units_per_pixel+units_per_pixel_min > 35) // this means resolution over 800x600
-        size_wide += size_wide>>3;
-    if (units_per_pixel+units_per_pixel_min > 55) // this means resolution over 1200x1024
-        size_wide += size_wide>>4;
     return  ((zoom_lvl*size_wide) >> 8) + ((zoom_lvl*size_narr) >> 8);
 }
 

--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -290,6 +290,21 @@ long get_camera_zoom(struct Camera *cam)
     }
 }
 
+/** When the menu is hidden in Isometric view, show less of the map (at max zoom out)
+    because the increased view exceeds the render array, and we want to hide the graphical glitches it causes)
+    otherwise this function just sets zoom_min = CAMERA_ZOOM_MIN
+ *
+ * @param cam The current player's camera.\
+ * @param showgui Whether the side-menu is visible or not (you should pass "game.operation_flags & GOF_ShowGui".\
+ */
+unsigned long adjust_min_camera_zoom(struct Camera *cam, int showgui)
+{
+  unsigned long zoom_min = CAMERA_ZOOM_MIN;
+  if (showgui == 0 && cam->view_mode == PVM_IsometricView)
+    zoom_min += 300; // a higher value is a nearer zoom
+  return zoom_min;
+}
+
 /** Scales camera zoom for current screen resolution.
  *
  * @param zoom_lvl Unscaled zoom level.

--- a/src/engine_camera.h
+++ b/src/engine_camera.h
@@ -103,6 +103,7 @@ void view_zoom_camera_in(struct Camera *cam, long limit_max, long limit_min);
 void set_camera_zoom(struct Camera *cam, long val);
 void view_zoom_camera_out(struct Camera *cam, long limit_max, long limit_min);
 long get_camera_zoom(struct Camera *cam);
+unsigned long adjust_min_camera_zoom(struct Camera *cam, int showgui);
 unsigned long scale_camera_zoom_to_screen(unsigned long zoom_lvl);
 void update_camera_zoom_bounds(struct Camera *cam,unsigned long zoom_max,unsigned long zoom_min);
 

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2393,9 +2393,25 @@ void set_gui_visible(TbBool visible)
       break;
   }
   if (((game.numfield_D & GNFldD_Unkn20) != 0) && ((game.operation_flags & GOF_ShowGui) != 0))
-    setup_engine_window(status_panel_width, 0, MyScreenWidth, MyScreenHeight);
+  {
+      setup_engine_window(status_panel_width, 0, MyScreenWidth, MyScreenHeight);
+  }
   else
-    setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+  {
+      setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+  }
+  if (player->acamera)
+  {
+      if ((game.operation_flags & GOF_ShowGui) == 0)
+      {
+          //Without the gui sidebar, the camera cannot be zoomed in as much.
+          update_camera_zoom_bounds(player->acamera, CAMERA_ZOOM_MAX, CAMERA_ZOOM_MIN + 300);
+      }
+      else
+      {
+          update_camera_zoom_bounds(player->acamera, CAMERA_ZOOM_MAX, CAMERA_ZOOM_MIN);
+      }
+  }
 }
 
 void toggle_gui(void)

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2400,17 +2400,12 @@ void set_gui_visible(TbBool visible)
   {
       setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
   }
-  if (player->acamera)
+  // Adjust the bounds of zoom of the camera when the side-menu is toggled (in Isometric view) to hide graphical glitches
+  // Without the gui sidebar, the camera cannot be zoomed in as much.
+  // NOTE: This should be reverted if the render array is ever increased (i.e. can see more things on screen)
+  if (player->acamera && player->acamera->view_mode == PVM_IsometricView)
   {
-      if ((game.operation_flags & GOF_ShowGui) == 0)
-      {
-          //Without the gui sidebar, the camera cannot be zoomed in as much.
-          update_camera_zoom_bounds(player->acamera, CAMERA_ZOOM_MAX, CAMERA_ZOOM_MIN + 300);
-      }
-      else
-      {
-          update_camera_zoom_bounds(player->acamera, CAMERA_ZOOM_MAX, CAMERA_ZOOM_MIN);
-      }
+      update_camera_zoom_bounds(player->acamera, CAMERA_ZOOM_MAX, adjust_min_camera_zoom(player->acamera, game.operation_flags & GOF_ShowGui));
   }
 }
 

--- a/src/packets.c
+++ b/src/packets.c
@@ -1898,7 +1898,15 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
             break;
         }
     }
-    unsigned long zoom_min = CAMERA_ZOOM_MIN;
+    unsigned long zoom_min;
+    if ((game.operation_flags & GOF_ShowGui) == 0)
+    {
+        zoom_min = CAMERA_ZOOM_MIN + 300;
+    }
+    else
+    {
+        zoom_min = CAMERA_ZOOM_MIN;
+    }
     unsigned long zoom_max = CAMERA_ZOOM_MAX;
     if (pckt->control_flags & PCtr_ViewZoomIn)
     {

--- a/src/packets.c
+++ b/src/packets.c
@@ -1898,15 +1898,7 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
             break;
         }
     }
-    unsigned long zoom_min;
-    if ((game.operation_flags & GOF_ShowGui) == 0)
-    {
-        zoom_min = CAMERA_ZOOM_MIN + 300;
-    }
-    else
-    {
-        zoom_min = CAMERA_ZOOM_MIN;
-    }
+    unsigned long zoom_min = adjust_min_camera_zoom(cam, game.operation_flags & GOF_ShowGui); // = CAMERA_ZOOM_MIN (+300 if gui is hidden in Isometric view)
     unsigned long zoom_max = CAMERA_ZOOM_MAX;
     if (pckt->control_flags & PCtr_ViewZoomIn)
     {


### PR DESCRIPTION
These adjustments that are suggested to be removed seem to have been put in place before the menu could scale, to adjust for higher resolutions - either way they seem to be wrong. See comment below for images and more details...

The side menu is scaled now, removing these adjustments give much better results at higher resolutions (slightly more zoomed out - in line with 640x400).

There are no more graphical glitches than when using 640x400 mode. May still be slightly wrong for "weird" menu widths (e.g. 1280x720, 1280x1024, or any "high res" that is not 16:10). Will check add new solution if needed as suspected.