### PR TITLE
Add "campaign" CMDline option (for use with "level")

### DIFF
--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -1106,7 +1106,7 @@ TbBool is_campaign_loaded(void)
 {
     if (campaign.fname[0]=='\0')
         return false;
-    return (campaign.single_levels_count > 0) || (campaign.multi_levels_count > 0);
+    return (campaign.single_levels_count > 0) || (campaign.multi_levels_count > 0) || (campaign.freeplay_levels_count > 0);
 }
 
 /**

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -53,6 +53,9 @@
 extern "C" {
 #endif
 
+// Max length of the command line
+#define CMDLN_MAXLEN 259
+
 #define LEGAL_WIDTH  640
 #define LEGAL_HEIGHT 480
 

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -133,6 +133,7 @@ struct StartupParameters {
     unsigned char packet_checksum_verify;
     unsigned char force_ppro_poly;
     int frame_skip;
+    char selected_campaign[CMDLN_MAXLEN+1];
 #ifdef AUTOTESTING
     unsigned char autotest_flags;
     unsigned long autotest_exit_turn;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,8 +136,6 @@
 
 int test_variable;
 
-// Max length of the command line
-#define CMDLN_MAXLEN 259
 char cmndline[CMDLN_MAXLEN+1];
 unsigned short bf_argc;
 char *bf_argv[CMDLN_MAXLEN+1];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4474,6 +4474,22 @@ void wait_at_frontend(void)
     {
       WARNMSG("No valid mappack files found");
     }
+    //Set level number and campaign (for single level mode: GOF_SingleLevel)
+    if ((start_params.operation_flags & GOF_SingleLevel) != 0) {
+        if (!change_campaign(strcat(start_params.selected_campaign,".cfg"))) {
+            if (!change_campaign("")) {
+                ERRORLOG("Unable to load default campaign for the specified level CMD Line parameter");
+            }
+            else {
+                ERRORLOG("Unable to load campaign associated with the specified level CMD Line parameter, default loaded.");
+            }
+        }
+        set_selected_level_number(start_params.selected_level_number);
+        //game.selected_level_number = start_params.selected_level_number;
+    }
+    else {
+        set_selected_level_number(first_singleplayer_level());
+    }
     // Init load/save catalogue
     initialise_load_game_slots();
     // Prepare to enter PacketLoad game
@@ -4794,6 +4810,11 @@ short process_command_line(unsigned short argc, char *argv[])
       {
         set_flag_byte(&start_params.operation_flags,GOF_SingleLevel,true);
         level_num = atoi(pr2str);
+        narg++;
+      } else
+      if ( strcasecmp(parstr,"campaign") == 0 )
+      {
+        strcpy(start_params.selected_campaign, pr2str);
         narg++;
       } else
       if ( strcasecmp(parstr,"ppropoly") == 0 )


### PR DESCRIPTION
Fixes "level" CMDline option, post map packs.

Allows the user to provide a campaign/map pack CFG file for use with the level parameter. This will usually be required, but defaults to keeporig if missing or invalid.

Also ensures that the correct campaign and level are loaded before launching single level mode.

Usage:

-level 80 -campaign deepdngn

will load Morkardar from Deeper Dungeons