### PR TITLE
Destroy less windows - fix for windowed mode

### DIFF
--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -440,10 +440,17 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
         sdlFlags |= SDL_WINDOW_FULLSCREEN;
     }
     if (lbWindow != NULL) {
+        // We only need to create a new window if we now have a different resolution/mode to the existing window, so check new/old resolution and mode...
         int cw, ch, cflags;
         cflags = SDL_GetWindowFlags(lbWindow);
-        SDL_GetWindowSize(lbWindow, &cw, &ch); //We only need to create a new window if we now have a different resolution/mode to the last
-        if (!(mdinfo->Width == cw && mdinfo->Height == ch && (cflags & sdlFlags != 0))) { //So only destroy the exisiting one if the res/mode has changed
+        SDL_GetWindowSize(lbWindow, &cw, &ch);
+        TbBool sameResolution = mdinfo->Width == cw && mdinfo->Height == ch;
+        TbBool sameWindowMode = cflags & sdlFlags != 0;
+        TbBool stillInWindowedMode = (int)(sdlFlags & 1) == 0 && (int)(cflags & 1) == 0; // it is hard to detect if windowed mode (flag = 0) is still the same (i.e. no change of mode, still in windowed mode)
+        if (stillInWindowedMode) {
+            sameWindowMode = sameWindowMode || stillInWindowedMode;
+        }
+        if (!sameResolution || !sameWindowMode) { //.. and only destroy the exisiting one if the res/mode has changed
             SDL_DestroyWindow(lbWindow);
             lbWindow = NULL;
         }


### PR DESCRIPTION
A fix for my "Destroy less windows" pull request.

Windows of the same size were still being destroyed/recreated when using windowed mode. As SDL windowed mode has a flag of 0, this was getting missed by the check I added. This is now caught correctly by the check, and the check is reorganised, so as to be easier to read.