### PR TITLE
Fix High DPI displays

### DIFF
--- a/keeperfx.exe.manifest
+++ b/keeperfx.exe.manifest
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+        <security>
+            <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+
+<asmv3:application>
+  <asmv3:windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware> <!-- legacy -->
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness> <!-- falls back to pm if pmv2 is not available -->
+  </asmv3:windowsSettings>
+</asmv3:application>
+
+</assembly>

--- a/res/keeperfx_stdres.rc
+++ b/res/keeperfx_stdres.rc
@@ -18,10 +18,15 @@
  */
 /******************************************************************************/
 
+#define CREATEPROCESS_MANIFEST_RESOURCE_ID 1 //Defined manifest file
+#define RT_MANIFEST                       24 // Manifest Resource Type
+
 #include <windows.h> // include for version info constants
 #include "../src/version.h" // define values for version info
 
 A ICON MOVEABLE PURE LOADONCALL DISCARDABLE "keeperfx_icon.ico"
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "keeperfx.exe.manifest" //Add manifest to declare that keeperfx is "dpiAware"
 
 // Create version info block, using defines from the header file
 1 VERSIONINFO


### PR DESCRIPTION
The exe now includes a manifest, which declares that KeeperFX is dpiAware (Win7 and earlier) and has multi-monitor dpiAwareness (Win8.1 and later).

The Application now renders "as if DPI scaling is set to 100%".
It does not yet scale with DPI, but the Window and Rendering are no longer "too big" with a higher DPI. Works across monitors with different DPI scaling (windowed mode, as you have to move the window).

If you change DPI scale percentage whilst the game is running, then the window height gets messed up. This does not appear to affect fullscreen mode. [this should be resolved at some point, but it is a fringe case]

The manifest file requires the trustInfo section, to work with UAC, if it is missing, or if this file is invalid in some other way, the dpiAwareness settings will not be honoured.

The formatting of this manifest file, and the way to add it as a resource, were pieced together from the following sources:
- [getting manifest into the exe] - https://stackoverflow.com/questions/29003832/how-to-add-assembly-manifest-file-to-exe-file-created-with-netbeans-ide-c-min
- [formatting the manifest file] - https://stackoverflow.com/questions/13228185/how-to-configure-an-app-to-run-correctly-on-a-machine-with-a-high-dpi-setting-e/13228495#13228495
- [correct dpiAwareness settings] - https://stackoverflow.com/questions/23551112/how-can-i-set-the-dpiaware-property-in-a-windows-application-manifest-to-per-mo

Moving forward, this is a great resource for handling DPI with SDL:
- https://nlguillemot.wordpress.com/2016/12/11/high-dpi-rendering/