### PR TITLE
1player improvement

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -48,6 +48,7 @@ int max_track = 7;
 unsigned short AtmosRepeat = 1013;
 unsigned short AtmosStart = 1014;
 unsigned short AtmosEnd = 1034;
+extern TbBool AssignCpuKeepers = 0;
 
 /**
  * Language 3-char abbreviations.

--- a/src/config.h
+++ b/src/config.h
@@ -169,6 +169,7 @@ struct NetLevelDesc { // sizeof = 14
 extern unsigned short AtmosRepeat;
 extern unsigned short AtmosStart;
 extern unsigned short AtmosEnd;
+extern TbBool AssignCpuKeepers;
 
 extern unsigned int vid_scale_flags;
 /******************************************************************************/
@@ -192,6 +193,7 @@ extern short is_new_moon;
 extern short is_near_new_moon;
 extern unsigned long text_line_number;
 extern const struct NamedCommand lang_type[];
+extern const struct NamedCommand logicval_type[];
 /******************************************************************************/
 char *prepare_file_path_buf(char *ffullpath,short fgroup,const char *fname);
 char *prepare_file_path(short fgroup,const char *fname);

--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -60,6 +60,7 @@ const struct NamedCommand cmpgn_common_commands[] = {
   {"LAND_MARKERS",       18},
   {"HUMAN_PLAYER",       19},
   {"NAME_TEXT_ID",       20},
+  {"ASSIGN_CPU_KEEPERS", 21},
   {NULL,                  0},
   };
 
@@ -207,6 +208,7 @@ TbBool clear_campaign(struct GameCampaign *campgn)
   campgn->credits_data = NULL;
   reset_credits(campgn->credits);
   campgn->human_player = -1;
+  campgn->assignCpuKeepers = 0;
   return true;
 }
 
@@ -653,6 +655,16 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
                     CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file. Not a valid number.",
                       COMMAND_TEXT(cmd_num),config_textname);
                 }
+          }
+          break;
+      case 21: // ASSIGN_CPU_KEEPERS
+          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          if (i <= 0) {
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+          }
+          else if (i < 2) { // ASSIGN_CPU_KEEPERS = ON
+              campgn->assignCpuKeepers = 1;
           }
           break;
       case 0: // comment

--- a/src/config_campaigns.h
+++ b/src/config_campaigns.h
@@ -114,6 +114,7 @@ struct GameCampaign {
   unsigned long hiscore_count;
   // Human player color
   short human_player;
+  TbBool assignCpuKeepers;
 };
 
 struct HighScore {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4758,6 +4758,7 @@ short process_command_line(unsigned short argc, char *argv[])
   bad_param = 0;
   unsigned short narg;
   level_num = LEVELNUMBER_ERROR;
+  TbBool one_player_mode = 0;
   narg = 1;
   while ( narg < argc )
   {
@@ -4794,7 +4795,7 @@ short process_command_line(unsigned short argc, char *argv[])
       if (strcasecmp(parstr, "1player") == 0)
       {
           start_params.one_player = 1;
-          AssignCpuKeepers = 1;
+          one_player_mode = 1;
       } else
       if ((strcasecmp(parstr, "s") == 0) || (strcasecmp(parstr, "nosound") == 0))
       {
@@ -4955,6 +4956,11 @@ short process_command_line(unsigned short argc, char *argv[])
       else
       {
           level_num = 1;
+      }
+  }
+  else {
+      if (one_player_mode) {
+          AssignCpuKeepers = 1;
       }
   }
   start_params.selected_level_number = level_num;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4476,12 +4476,19 @@ void wait_at_frontend(void)
     }
     //Set level number and campaign (for single level mode: GOF_SingleLevel)
     if ((start_params.operation_flags & GOF_SingleLevel) != 0) {
-        if (!change_campaign(strcat(start_params.selected_campaign,".cfg"))) {
+        TbBool result = false;
+        if (start_params.selected_campaign[0] != '\0') {
+            result = change_campaign(strcat(start_params.selected_campaign,".cfg"));
+        }
+        if (!result) {
             if (!change_campaign("")) {
-                ERRORLOG("Unable to load default campaign for the specified level CMD Line parameter");
+                WARNMSG("Unable to load default campaign for the specified level CMD Line parameter");
+            }
+            else if (start_params.selected_campaign[0] != '\0') { // only show this log message if the user actually specified a campaign
+                WARNMSG("Unable to load campaign associated with the specified level CMD Line parameter, default loaded.");
             }
             else {
-                ERRORLOG("Unable to load campaign associated with the specified level CMD Line parameter, default loaded.");
+                JUSTLOG("No campaign specified. Default campaign loaded for selected level (%d).", start_params.selected_level_number);
             }
         }
         set_selected_level_number(start_params.selected_level_number);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4404,16 +4404,20 @@ void startup_network_game(TbBool local)
     player = get_my_player();
     player->field_2C = flgmem;
     //if (game.flagfield_14EA4A == 2) //was wrong because init_level sets this to 2. global variables are evil (though perhaps that's why they were chosen for DK? ;-))
+    TbBool ShouldAssignCpuKeepers = 0;
     if (local)
     {
         game.game_kind = GKind_LocalGame;
         init_players_local_game();
+        if (AssignCpuKeepers || campaign.assignCpuKeepers) {
+            ShouldAssignCpuKeepers = 1;
+        }
     } else
     {
         game.game_kind = GKind_MultiGame;
         init_players_network_game();
     }
-    if (fe_computer_players)
+    if (fe_computer_players || ShouldAssignCpuKeepers)
     {
         SYNCDBG(5,"Setting up uninitialized players as computer players");
         setup_computer_players();
@@ -4742,6 +4746,7 @@ short process_command_line(unsigned short argc, char *argv[])
   else
       strcpy(keeper_runtime_directory, ".");
 
+  AssignCpuKeepers = 0;
   SoundDisabled = 0;
   // Note: the working log file is set up in LbBullfrogMain
   LbErrorLogSetup(0, 0, 1);
@@ -4789,6 +4794,7 @@ short process_command_line(unsigned short argc, char *argv[])
       if (strcasecmp(parstr, "1player") == 0)
       {
           start_params.one_player = 1;
+          AssignCpuKeepers = 1;
       } else
       if ((strcasecmp(parstr, "s") == 0) || (strcasecmp(parstr, "nosound") == 0))
       {


### PR DESCRIPTION
A fix for the level command (see commit "removes wasteful load of empty campaign").

And, the ability to add CPU Keepers to a map:

- Use ASSIGN_CPU_KEEPERS=ON in a map pack or campaign cfg file

or

- use the 1player command line option

 to fill all of the empty keeper slots with CPU keepers.

Respects all previous functionality: setup_computer_players() is only run when it should be, using a few new boolean variables to store the user's settings, and changing "if (fe_computer_players)" to "if (fe_computer_players || ShouldAssignCpuKeepers)" in main.cpp.