### PR TITLE
Allow pointer sensitivity be the same as system

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -15,7 +15,9 @@ FRONTEND_RES=640x480x32 640x480x32 640x480x32
 ; Original DK resolutions were INGAME_RES=320x200x8 640x400x8
 INGAME_RES=640x480x32 1366x768x32 1920x1080x32
 
-; Mouse pointer movement speed; 100 percent means normal OS speed
+; Mouse pointer movement speed.
+; Set to 0 for normal OS speed.
+; With value more than 0 sensitivity will also depend on resolution.
 POINTER_SENSITIVITY=100
 
 ; Censorship - originally was ON only if language is german.

--- a/src/bflib_inputctrl.cpp
+++ b/src/bflib_inputctrl.cpp
@@ -275,7 +275,7 @@ static void process_event(const SDL_Event *ev)
         break;
 
     case SDL_MOUSEMOTION:
-        if (lbMouseGrab)
+        if (lbMouseGrab && lbDisplay.MouseMoveRatio > 0)
         {
             mouseDelta.x = ev->motion.xrel * lbDisplay.MouseMoveRatio / 256;
             mouseDelta.y = ev->motion.yrel * lbDisplay.MouseMoveRatio / 256;

--- a/src/config.c
+++ b/src/config.c
@@ -688,7 +688,7 @@ short load_configuration(void)
           {
             i = atoi(word_buf);
           }
-          if ((i > 0) && (i <= 1000)) {
+          if ((i >= 0) && (i <= 1000)) {
               base_mouse_sensitivity = i*256/100;
           } else {
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",


### PR DESCRIPTION
As I ported the game to SDL2 I played entire original campaign with mouse sensitivity of my system. After I added a patch that takes `POINTER_SENSITIVITY` into account it feels a little bit off for me. So I decided to add a little feature: if you set `POINTER_SENSITIVITY` to 0, it'll be the same as your system. If it's greater, then old math happens and pointer sensitivity scales with display resolution.